### PR TITLE
[DB] 회원 - 태그 매핑 테이블 생성

### DIFF
--- a/src/main/java/com/bonheur/domain/member/model/Member.java
+++ b/src/main/java/com/bonheur/domain/member/model/Member.java
@@ -2,6 +2,7 @@ package com.bonheur.domain.member.model;
 
 import com.bonheur.domain.board.model.Board;
 import com.bonheur.domain.common.BaseEntity;
+import com.bonheur.domain.membertag.model.MemberTag;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,6 +31,9 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member")
     private List<Board> boards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<MemberTag> memberTags = new ArrayList<>();
 
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/bonheur/domain/membertag/model/MemberTag.java
+++ b/src/main/java/com/bonheur/domain/membertag/model/MemberTag.java
@@ -1,0 +1,41 @@
+package com.bonheur.domain.membertag.model;
+
+import com.bonheur.domain.common.BaseEntity;
+import com.bonheur.domain.member.model.Member;
+import com.bonheur.domain.tag.model.Tag;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MemberTag extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public MemberTag(Member member, Tag tag) {
+        this.member = member;
+        this.tag = tag;
+    }
+
+    public static MemberTag newMemberTag(Member member, Tag tag) {
+        return MemberTag.builder()
+                .member(member)
+                .tag(tag)
+                .build();
+    }
+}

--- a/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepository.java
+++ b/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepository.java
@@ -1,0 +1,8 @@
+package com.bonheur.domain.membertag.repository;
+
+import com.bonheur.domain.membertag.model.MemberTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface MemberTagRepository extends JpaRepository<MemberTag,Long>, MemberTagRepositoryCustom {
+}

--- a/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.bonheur.domain.membertag.repository;
+
+public interface MemberTagRepositoryCustom {
+}

--- a/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepositoryCustomImpl.java
@@ -1,0 +1,9 @@
+package com.bonheur.domain.membertag.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberTagRepositoryCustomImpl implements MemberTagRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+}

--- a/src/main/java/com/bonheur/domain/membertag/service/MemberTagService.java
+++ b/src/main/java/com/bonheur/domain/membertag/service/MemberTagService.java
@@ -1,0 +1,4 @@
+package com.bonheur.domain.membertag.service;
+
+public interface MemberTagService {
+}

--- a/src/main/java/com/bonheur/domain/membertag/service/MemberTagServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/membertag/service/MemberTagServiceImpl.java
@@ -1,0 +1,11 @@
+package com.bonheur.domain.membertag.service;
+
+import com.bonheur.domain.membertag.repository.MemberTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberTagServiceImpl implements MemberTagService {
+    private final MemberTagRepository memberTagRepository;
+}

--- a/src/main/java/com/bonheur/domain/tag/model/Tag.java
+++ b/src/main/java/com/bonheur/domain/tag/model/Tag.java
@@ -2,6 +2,7 @@ package com.bonheur.domain.tag.model;
 
 import com.bonheur.domain.boardtag.model.BoardTag;
 import com.bonheur.domain.common.BaseEntity;
+import com.bonheur.domain.membertag.model.MemberTag;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +24,9 @@ public class Tag extends BaseEntity {
 
     @OneToMany(mappedBy = "tag")
     private List<BoardTag> boardTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "tag")
+    private List<MemberTag> memberTags = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Tag(String name){


### PR DESCRIPTION
#83 

## 작업사항
 회원-태그 매핑 테이블 생성
 회원 엔티티 수정
 태그 엔티티 수정

## 참고 사항
- 태그 사용 통계 API 작성 시 사용 유효
- 게시물을 삭제하는 경우에 태그와의 연관관계가 끊어지기 때문에 회원과의 연관관계 유지를 위해 연관관계 매핑 테이블 추가