### PR TITLE
[Feat] 회원 탈퇴 API 추가

### DIFF
--- a/src/main/java/com/bonheur/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bonheur/domain/auth/controller/AuthController.java
@@ -11,10 +11,7 @@ import com.bonheur.domain.auth.service.AuthService;
 import com.bonheur.domain.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
@@ -66,6 +63,19 @@ public class AuthController {
             @Valid @MemberId Long memberId
     ) {
         httpSession.invalidate();
-        return ApiResponse.success("로그아웃을 요청합니다.");
+        return ApiResponse.success("로그아웃이 되었습니다.");
+    }
+
+    @ApiDocumentResponse
+    @Operation(summary = "회원 탈퇴 요청")
+    // 이상 Swagger 코드
+    @Auth
+    @DeleteMapping("/auth/withdrawal")
+    public ApiResponse<String> withdrawal(
+            @Valid @MemberId Long memberId
+    ) {
+        authService.withdrawal(memberId);
+        httpSession.invalidate();
+        return ApiResponse.success("회원 탈퇴가 되었습니다.");
     }
 }

--- a/src/main/java/com/bonheur/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bonheur/domain/auth/service/AuthService.java
@@ -7,4 +7,6 @@ public interface AuthService {
     Long signUp(SocialSignUpRequest request);
 
     Long login(LoginRequest request);
+
+    void withdrawal(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/auth/service/AuthServiceImpl.java
@@ -3,11 +3,14 @@ package com.bonheur.domain.auth.service;
 import com.bonheur.config.provider.AuthProvider;
 import com.bonheur.domain.auth.model.dto.LoginRequest;
 import com.bonheur.domain.auth.model.dto.SocialSignUpRequest;
+import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.repository.MemberRepository;
 import com.bonheur.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -29,5 +32,15 @@ public class AuthServiceImpl implements AuthService {
         AuthProvider authProvider = authProviderFinder.findAuthProvider(request.getSocialType());
         String socialId = authProvider.getSocialId(request.getToken());
         return memberRepository.findMemberBySocialInfo(socialId, request.getSocialType()).getId();
+    }
+
+    @Override
+    public void withdrawal(Long memberId) {
+        Optional<Member> member = memberRepository.findById(memberId);
+        if (member.isEmpty()) {
+            throw new RuntimeException("존재하지 않는 유저입니다.");
+        }
+        // 게시물 삭제 로직 추가 필요
+        memberRepository.delete(member.get());
     }
 }

--- a/src/main/java/com/bonheur/domain/member/model/Member.java
+++ b/src/main/java/com/bonheur/domain/member/model/Member.java
@@ -8,10 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,10 +26,10 @@ public class Member extends BaseEntity {
     private MemberProfile profile;
 
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Board> boards = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberTag> memberTags = new ArrayList<>();
 
 

--- a/src/main/java/com/bonheur/domain/tag/model/Tag.java
+++ b/src/main/java/com/bonheur/domain/tag/model/Tag.java
@@ -8,10 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,10 +19,10 @@ public class Tag extends BaseEntity {
     @Column(nullable = false, length = 10)
     private String name;
 
-    @OneToMany(mappedBy = "tag")
+    @OneToMany(mappedBy = "tag",cascade = CascadeType.ALL)
     private List<BoardTag> boardTags = new ArrayList<>();
 
-    @OneToMany(mappedBy = "tag")
+    @OneToMany(mappedBy = "tag",cascade = CascadeType.ALL)
     private List<MemberTag> memberTags = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
#69 
## 작업사항

- 회원 탈퇴 API 추가
- 회원 , 태그 영속성 전이 옵션 지정

## 내용
세션 불 일치 시 회원탈퇴 불가
![image](https://user-images.githubusercontent.com/76430979/214039797-2e19c444-9ee6-40f7-b3c4-a1d4c02acfde.png)
세션 일치 시 회원탈퇴 완료 ( memberId 생략 가능 )
![image](https://user-images.githubusercontent.com/76430979/214039929-724544c5-cebc-4564-bd66-f9ff74b5587b.png)
