### PR TITLE
[Feat] 회원 최근 사용 태그 조회

### DIFF
--- a/src/main/java/com/bonheur/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bonheur/domain/member/controller/MemberController.java
@@ -76,4 +76,11 @@ public class MemberController {
         return ApiResponse.success(memberService.findMyMonthRecord(memberId));
     }
 
+    @ApiDocumentResponse
+    @Operation(summary = "회원 최근 사용 태그 조회")
+    @GetMapping("/api/member/tags")
+    public ApiResponse<List<GetTagUsedByMemberResponse>> getTagUsedByMember() {
+        Long memberId = 1L;
+        return ApiResponse.success(memberService.getTagUsedByMember(memberId));
+    }
 }

--- a/src/main/java/com/bonheur/domain/member/model/dto/GetTagUsedByMemberResponse.java
+++ b/src/main/java/com/bonheur/domain/member/model/dto/GetTagUsedByMemberResponse.java
@@ -1,0 +1,18 @@
+package com.bonheur.domain.member.model.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetTagUsedByMemberResponse {
+    private Long tagId;
+    private String tagName;
+
+    public static GetTagUsedByMemberResponse of(Long tagId,String tagName) {
+        return new GetTagUsedByMemberResponse(tagId, tagName);
+    }
+}

--- a/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.bonheur.domain.member.repository;
 import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.model.MemberSocialType;
 import com.bonheur.domain.member.model.dto.*;
+import com.bonheur.domain.tag.model.Tag;
 
 import java.util.List;
 
@@ -19,4 +20,5 @@ public interface MemberRepositoryCustom {
     List<FindMonthRecordResponse> findMonthRecordByMemberId(Long memberId);
 
 
+    List<Tag> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.bonheur.domain.member.repository;
 import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.model.MemberSocialType;
 import com.bonheur.domain.member.model.dto.*;
+import com.bonheur.domain.tag.model.Tag;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.dsl.NumberOperation;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -13,6 +14,7 @@ import java.util.List;
 import static com.bonheur.domain.board.model.QBoard.board;
 import static com.bonheur.domain.boardtag.model.QBoardTag.boardTag;
 import static com.bonheur.domain.member.model.QMember.member;
+import static com.bonheur.domain.membertag.model.QMemberTag.memberTag;
 import static com.bonheur.domain.tag.model.QTag.tag;
 import static com.querydsl.core.types.Projections.*;
 import static com.querydsl.core.types.dsl.Expressions.numberOperation;
@@ -158,5 +160,20 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<Tag> getTagUsedByMember(Long memberId) {
+        return queryFactory.select(tag)
+                .from(tag)
+                .leftJoin(tag.memberTags,memberTag).fetchJoin()
+                .leftJoin(memberTag.member).fetchJoin()
+                .where(
+                        memberTag.member.id.eq(memberId)
+                )
+                .distinct()
+                .orderBy(memberTag.updatedAt.desc())
+                .offset(0)
+                .limit(5)
+                .fetch();
+    }
 }
 

--- a/src/main/java/com/bonheur/domain/member/service/MemberService.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberService.java
@@ -19,4 +19,6 @@ public interface MemberService {
 
     List<FindDayRecordResponse> findMyDayRecord(Long memberId);
     List<FindMonthRecordResponse> findMyMonthRecord(Long memberId);
+
+    List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -94,6 +94,12 @@ public class MemberServiceImpl implements MemberService{
     @Override
     @Transactional
     public List<FindMonthRecordResponse> findMyMonthRecord(Long memberId) { return memberRepository.findMonthRecordByMemberId(memberId); }
+
+    @Override
+    @Transactional
+    public List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId) {
+        return memberRepository.getTagUsedByMember(memberId).stream().map(tag -> GetTagUsedByMemberResponse.of(tag.getId(),tag.getName())).collect(Collectors.toList());
+    }
 }
 
 


### PR DESCRIPTION
#100 
## 작업사항

- 회원 최근 사용 태그 조회

## 업데이트 시간 순 최근 사용 태그 5개 조회 ( 1번부터 8번까지 순서대로 생성, 2번의 태그 업데이트 )
![image](https://user-images.githubusercontent.com/76430979/214870317-08eda9f3-1acc-4369-b1c9-c8d3e81e4c80.png)
![image](https://user-images.githubusercontent.com/76430979/214870290-3ddc1998-e00f-4c92-b39b-ca738ed0a251.png)
## 5개 미만의 태그가 존재하는 경우 → 그 이하로 조회된다.
![image](https://user-images.githubusercontent.com/76430979/214870391-1b7b28d7-fedf-41b6-859f-adff8e618986.png)
![image](https://user-images.githubusercontent.com/76430979/214870417-5b746c68-bd0b-459e-89b8-243159c29a43.png)
