### PR TITLE
[Fix] 'Board' 전체 조회 및 태그로 조회 날짜별로 그룹화

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -4,7 +4,6 @@ import com.bonheur.config.swagger.dto.ApiDocumentResponse;
 import com.bonheur.domain.board.model.dto.*;
 import com.bonheur.domain.board.service.BoardService;
 import com.bonheur.domain.common.dto.ApiResponse;
-import com.bonheur.domain.common.exception.dto.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -26,10 +25,11 @@ public class BoardController {
     @ApiDocumentResponse
     @Operation(summary = "행복기록 전체 조회")
     @GetMapping("/api/boards")
-    public ApiResponse<Slice<GetBoardsResponse>> getAllBoards(@RequestParam(required = false) Long lastBoardId, @RequestParam Long memberId, @PageableDefault(size = 5) Pageable pageable) {
+    public ApiResponse<GetBoardsGroupsResponse> getAllBoards(@RequestParam(required = false) Long lastBoardId, @RequestParam Long memberId, @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, pageable);
+        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses);
 
-        return ApiResponse.success(getBoardsResponses);
+        return ApiResponse.success(getBoardsGroupsResponse);
     }
 
     // # 게시글 삭제
@@ -48,14 +48,15 @@ public class BoardController {
     @Operation(summary = "행복기록 조회 - 해시태그")
     @ResponseBody
     @PostMapping ("/api/boards/tag")
-    public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
+    public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(
             @RequestParam(required = false) Long lastBoardId, Long memberId,
             @RequestBody GetBoardByTagRequest getBoardByTagRequest,
             @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
                 boardService.getBoardsByTag(lastBoardId, memberId, getBoardByTagRequest.getTagIds(), pageable);
+        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses);
 
-        return ApiResponse.success(getBoardsResponses);
+        return ApiResponse.success(getBoardsGroupsResponse);
     }
 
     @PostMapping("/api/boards")

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
@@ -6,15 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardsGroupsResponse {
-    private String date; // 형식 : 00월 00일 0요일
-    private List<GetBoardsResponse> getBoardsResponses;
-
-    public static GetBoardsGroupsResponse of(String date, List<GetBoardsResponse> getBoardsResponses) {
-        return new GetBoardsGroupsResponse(date, getBoardsResponses);
+    private Map<String, List<GetBoardsResponse>> group;
+    public static GetBoardsGroupsResponse of(Map<String, List<GetBoardsResponse>> group) {
+        return new GetBoardsGroupsResponse(group);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
@@ -1,0 +1,20 @@
+package com.bonheur.domain.board.model.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetBoardsGroupsResponse {
+    private String date; // 형식 : 00월 00일 0요일
+    private List<GetBoardsResponse> getBoardsResponses;
+
+    public static GetBoardsGroupsResponse of(String date, List<GetBoardsResponse> getBoardsResponses) {
+        return new GetBoardsGroupsResponse(date, getBoardsResponses);
+    }
+}

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
@@ -14,16 +14,18 @@ public class GetBoardsResponse {
     private String contents;
     private List<String> boardTags;
     private String image; // 대표 이미지 url
-    private String createdAt;
+    private String createdAtDate; // 형식 : 00월 00일 0요일
+    private String createdAtTime; // 형식 : 0M 00:00
 
-    private GetBoardsResponse(String contents, List<String> boardTags, String createdAt) {
+    private GetBoardsResponse(String contents, List<String> boardTags, String createdAtDate, String createdAtTime) {
         this.contents = contents;
         this.boardTags = boardTags;
-        this.createdAt = createdAt;
+        this.createdAtDate= createdAtDate;
+        this.createdAtTime = createdAtTime;
     }
 
-    public static GetBoardsResponse of(String contents, List<String> boardTags, String image, String createdAt) {
-        if (image == null) return new GetBoardsResponse(contents, boardTags, createdAt);
-        return new GetBoardsResponse(contents, boardTags, image, createdAt);
+    public static GetBoardsResponse of(String contents, List<String> boardTags, String image, String createdAtDate, String createdAtTime) {
+        if (image == null) return new GetBoardsResponse(contents, boardTags, createdAtDate, createdAtTime);
+        return new GetBoardsResponse(contents, boardTags, image, createdAtDate, createdAtTime);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -37,7 +37,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     }
 
     @Override
-    // # 게시글 조회 - by TagName (무한 스크롤, no-offset)
+    // # 게시글 조회 - by Tag (무한 스크롤, no-offset)
     public Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable) {
         List<Board> results = queryFactory.selectFrom(board)
                 .where(

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -15,4 +15,5 @@ public interface BoardService {
      CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
      UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
      GetBoardResponse getBoard(Long boardId);
+     GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice);
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -50,7 +50,6 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     // # 날짜별 그룹화
     public GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice) {
-
         List<GetBoardsResponse> getBoardsResponsesOfSlice = getBoardsResponseSlice.getContent();
         return GetBoardsGroupsResponse.of(getBoardsResponsesOfSlice.stream().collect(Collectors.groupingBy(GetBoardsResponse::getCreatedAtDate)));
     }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -40,8 +41,18 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findAllWithPaging(lastBoardId, memberId, pageable)
                 .map(board -> GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
-                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")))
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
                 );
+    }
+
+    @Override
+    @Transactional
+    // # 날짜별 그룹화
+    public GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice) {
+
+        List<GetBoardsResponse> getBoardsResponsesOfSlice = getBoardsResponseSlice.getContent();
+        return GetBoardsGroupsResponse.of(getBoardsResponsesOfSlice.stream().collect(Collectors.groupingBy(GetBoardsResponse::getCreatedAtDate)));
     }
 
     // # Tag Name을 String List로 받아오기
@@ -77,7 +88,8 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, pageable)
                 .map(board -> GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
-                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")))
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
                 );
     }
 


### PR DESCRIPTION
## 개요
#104 ``[Fix] 전체 조회 및 해시 태그로 조회 날짜로 그룹화``

## 작업 사항
- [x] BoardService에 날짜별 그룹화 로직 추가 : getBoardsGroups
- [x] BoardController반환 값 getBoardsGroups 사용하여 GetBoardsGroupsResponse로 변경