### PR TITLE
[Refactor] 행복 기록 작성 및 수정 기능 관련 코드

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -46,7 +46,7 @@ public class BoardController {
     @PostMapping ("/api/boards/tag")
     public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
             @RequestParam(required = false) Long lastBoardId, @RequestBody GetBoardByTagRequest getBoardByTagRequest,
-            @RequestParam(required = false) @PageableDefault(size = 5) Pageable pageable) {
+            @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
                 boardService.getBoardsByTag(lastBoardId, getBoardByTagRequest.getMemberId(), getBoardByTagRequest.getTagIds(), pageable);
 

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -45,8 +45,8 @@ public class BoardController {
     @ResponseBody
     @PostMapping ("/api/boards/tag")
     public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
-            Long lastBoardId, @RequestBody GetBoardByTagRequest getBoardByTagRequest,
-            @PageableDefault(size = 5) Pageable pageable) {
+            @RequestParam(required = false) Long lastBoardId, @RequestBody GetBoardByTagRequest getBoardByTagRequest,
+            @RequestParam(required = false) @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
                 boardService.getBoardsByTag(lastBoardId, getBoardByTagRequest.getMemberId(), getBoardByTagRequest.getTagIds(), pageable);
 

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -39,9 +39,7 @@ public class BoardController {
     @DeleteMapping("/api/boards/{boardId}")
     public ApiResponse<DeleteBoardResponse> deleteBoard(Long memberId, @PathVariable("boardId") Long boardId) {
         DeleteBoardResponse deleteBoardResponse = boardService.deleteBoard(memberId, boardId);
-        if (deleteBoardResponse.getBoardId().equals(boardId))
-            return ApiResponse.success(deleteBoardResponse);
-        else return ApiResponse.error(ErrorCode.E400_INVALID_AUTH_TOKEN);
+        return ApiResponse.success(deleteBoardResponse);
     }
 
     // # 게시글 조회 - 해시태그

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -45,7 +45,7 @@ public class BoardController {
     @ResponseBody
     @PostMapping ("/api/boards/tag")
     public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
-            Long lastBoardId, @RequestBody GetBoardByTagRequest getBoardByTagRequest,
+            Long lastBoardId, @RequestParam GetBoardByTagRequest getBoardByTagRequest,
             @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
                 boardService.getBoardsByTag(lastBoardId, getBoardByTagRequest.getMemberId(), getBoardByTagRequest.getTagIds(), pageable);

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -40,6 +40,15 @@ public class BoardController {
         else return ApiResponse.error(ErrorCode.E400_INVALID_AUTH_TOKEN);
     }
 
+    // # 게시글 조회 - 해시태그
+    // 회원 인증 어노테이션 추가 필요
+    @GetMapping("/api/boards/{tagName}")
+    public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(Long lastBoardId, Long memberId, @PathVariable("tagName") String tagName, @PageableDefault(size = 5) Pageable pageable) {
+        Slice<GetBoardsResponse> getBoardsResponses = boardService.getBoardsByTag(lastBoardId, memberId, tagName, pageable);
+
+        return ApiResponse.success(getBoardsResponses);
+    }
+
     @PostMapping("/api/boards")
     public ApiResponse<CreateBoardResponse> createBoard(
             @RequestPart(value = "images") List<MultipartFile> images,

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -23,6 +23,8 @@ public class BoardController {
 
     // # 게시글 전체 조회 (페이징 일단 5개로 정의)
     // 회원 인증 어노테이션 추가 필요
+    @ApiDocumentResponse
+    @Operation(summary = "행복기록 전체 조회")
     @GetMapping("/api/boards")
     public ApiResponse<Slice<GetBoardsResponse>> getAllBoards(@RequestParam(required = false) Long lastBoardId, @RequestParam Long memberId, @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, pageable);
@@ -32,6 +34,8 @@ public class BoardController {
 
     // # 게시글 삭제
     // 회원 인증 어노테이션 추가 필요
+    @ApiDocumentResponse
+    @Operation(summary = "행복기록 삭제")
     @DeleteMapping("/api/boards/{boardId}")
     public ApiResponse<DeleteBoardResponse> deleteBoard(Long memberId, @PathVariable("boardId") Long boardId) {
         DeleteBoardResponse deleteBoardResponse = boardService.deleteBoard(memberId, boardId);
@@ -42,6 +46,8 @@ public class BoardController {
 
     // # 게시글 조회 - 해시태그
     // 회원 인증 어노테이션 추가 필요
+    @ApiDocumentResponse
+    @Operation(summary = "행복기록 조회 - 해시태그")
     @ResponseBody
     @PostMapping ("/api/boards/tag")
     public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
@@ -54,6 +60,8 @@ public class BoardController {
         return ApiResponse.success(getBoardsResponses);
     }
 
+    @ApiDocumentResponse
+    @Operation(summary = "행복기록 작성")
     @PostMapping("/api/boards")
     public ApiResponse<CreateBoardResponse> createBoard(
             @RequestPart(value = "images") List<MultipartFile> images,
@@ -64,6 +72,8 @@ public class BoardController {
         return ApiResponse.success(boardService.createBoard(memberId, createBoardRequest, images));
     }
 
+    @ApiDocumentResponse
+    @Operation(summary = "행복기록 수정")
     @PatchMapping("/api/boards/{boardId}")
     public ApiResponse<UpdateBoardResponse> updateBoard(
             @PathVariable("boardId") Long boardId,

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -45,7 +45,7 @@ public class BoardController {
     @ResponseBody
     @PostMapping ("/api/boards/tag")
     public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
-            @RequestParam(required = false) Long lastBoardId, @RequestParam Long memberId,
+            @RequestParam(required = false) Long lastBoardId, Long memberId,
             @RequestBody GetBoardByTagRequest getBoardByTagRequest,
             @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -45,7 +45,7 @@ public class BoardController {
     @ResponseBody
     @PostMapping ("/api/boards/tag")
     public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
-            Long lastBoardId, @RequestParam GetBoardByTagRequest getBoardByTagRequest,
+            Long lastBoardId, @RequestBody GetBoardByTagRequest getBoardByTagRequest,
             @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
                 boardService.getBoardsByTag(lastBoardId, getBoardByTagRequest.getMemberId(), getBoardByTagRequest.getTagIds(), pageable);

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -60,8 +60,6 @@ public class BoardController {
         return ApiResponse.success(getBoardsResponses);
     }
 
-    @ApiDocumentResponse
-    @Operation(summary = "행복기록 작성")
     @PostMapping("/api/boards")
     public ApiResponse<CreateBoardResponse> createBoard(
             @RequestPart(value = "images") List<MultipartFile> images,
@@ -72,8 +70,6 @@ public class BoardController {
         return ApiResponse.success(boardService.createBoard(memberId, createBoardRequest, images));
     }
 
-    @ApiDocumentResponse
-    @Operation(summary = "행복기록 수정")
     @PatchMapping("/api/boards/{boardId}")
     public ApiResponse<UpdateBoardResponse> updateBoard(
             @PathVariable("boardId") Long boardId,

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -4,6 +4,7 @@ import com.bonheur.config.swagger.dto.ApiDocumentResponse;
 import com.bonheur.domain.board.model.dto.*;
 import com.bonheur.domain.board.service.BoardService;
 import com.bonheur.domain.common.dto.ApiResponse;
+import com.bonheur.domain.common.exception.dto.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -27,6 +28,16 @@ public class BoardController {
         Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, pageable);
 
         return ApiResponse.success(getBoardsResponses);
+    }
+
+    // # 게시글 삭제
+    // 회원 인증 어노테이션 추가 필요
+    @DeleteMapping("/api/boards/{boardId}")
+    public ApiResponse<DeleteBoardResponse> deleteBoard(Long memberId, @PathVariable("boardId") Long boardId) {
+        DeleteBoardResponse deleteBoardResponse = boardService.deleteBoard(memberId, boardId);
+        if (deleteBoardResponse.getBoardId().equals(boardId))
+            return ApiResponse.success(deleteBoardResponse);
+        else return ApiResponse.error(ErrorCode.E400_INVALID_AUTH_TOKEN);
     }
 
     @PostMapping("/api/boards")

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -42,9 +42,13 @@ public class BoardController {
 
     // # 게시글 조회 - 해시태그
     // 회원 인증 어노테이션 추가 필요
-    @GetMapping("/api/boards/{tagName}")
-    public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(Long lastBoardId, Long memberId, @PathVariable("tagName") String tagName, @PageableDefault(size = 5) Pageable pageable) {
-        Slice<GetBoardsResponse> getBoardsResponses = boardService.getBoardsByTag(lastBoardId, memberId, tagName, pageable);
+    @ResponseBody
+    @PostMapping ("/api/boards/tag")
+    public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
+            Long lastBoardId, @RequestBody GetBoardByTagRequest getBoardByTagRequest,
+            @PageableDefault(size = 5) Pageable pageable) {
+        Slice<GetBoardsResponse> getBoardsResponses =
+                boardService.getBoardsByTag(lastBoardId, getBoardByTagRequest.getMemberId(), getBoardByTagRequest.getTagIds(), pageable);
 
         return ApiResponse.success(getBoardsResponses);
     }

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -6,6 +6,9 @@ import com.bonheur.domain.board.service.BoardService;
 import com.bonheur.domain.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,6 +19,15 @@ import java.util.List;
 @RestController
 public class BoardController {
     private final BoardService boardService;
+
+    // # 게시글 전체 조회 (페이징 일단 5개로 정의)
+    // 회원 인증 어노테이션 추가 필요
+    @GetMapping("/api/boards")
+    public ApiResponse<Slice<GetBoardsResponse>> getAllBoards(Long lastBoardId, Long memberId, @PageableDefault(size = 5) Pageable pageable) {
+        Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, pageable);
+
+        return ApiResponse.success(getBoardsResponses);
+    }
 
     @PostMapping("/api/boards")
     public ApiResponse<CreateBoardResponse> createBoard(

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -24,7 +24,7 @@ public class BoardController {
     // # 게시글 전체 조회 (페이징 일단 5개로 정의)
     // 회원 인증 어노테이션 추가 필요
     @GetMapping("/api/boards")
-    public ApiResponse<Slice<GetBoardsResponse>> getAllBoards(Long lastBoardId, Long memberId, @PageableDefault(size = 5) Pageable pageable) {
+    public ApiResponse<Slice<GetBoardsResponse>> getAllBoards(@RequestParam(required = false) Long lastBoardId, @RequestParam Long memberId, @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, pageable);
 
         return ApiResponse.success(getBoardsResponses);
@@ -45,10 +45,11 @@ public class BoardController {
     @ResponseBody
     @PostMapping ("/api/boards/tag")
     public ApiResponse<Slice<GetBoardsResponse>> getBoardsByTag(
-            @RequestParam(required = false) Long lastBoardId, @RequestBody GetBoardByTagRequest getBoardByTagRequest,
+            @RequestParam(required = false) Long lastBoardId, @RequestParam Long memberId,
+            @RequestBody GetBoardByTagRequest getBoardByTagRequest,
             @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
-                boardService.getBoardsByTag(lastBoardId, getBoardByTagRequest.getMemberId(), getBoardByTagRequest.getTagIds(), pageable);
+                boardService.getBoardsByTag(lastBoardId, memberId, getBoardByTagRequest.getTagIds(), pageable);
 
         return ApiResponse.success(getBoardsResponses);
     }

--- a/src/main/java/com/bonheur/domain/board/model/dto/DeleteBoardResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/DeleteBoardResponse.java
@@ -1,0 +1,18 @@
+package com.bonheur.domain.board.model.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteBoardResponse {
+    private Long boardId;
+
+    // parameter 한 개여서 public으로 작성
+    @Builder
+    public DeleteBoardResponse(Long boardId){
+        this.boardId = boardId;
+    }
+}

--- a/src/main/java/com/bonheur/domain/board/model/dto/DeleteBoardResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/DeleteBoardResponse.java
@@ -1,18 +1,14 @@
 package com.bonheur.domain.board.model.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DeleteBoardResponse {
     private Long boardId;
 
-    // parameter 한 개여서 public으로 작성
-    @Builder
-    public DeleteBoardResponse(Long boardId){
-        this.boardId = boardId;
+    public static DeleteBoardResponse of(Long boardId) {
+        return new DeleteBoardResponse(boardId);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
@@ -9,6 +9,5 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardByTagRequest {
-    private Long memberId;
     private List<Long> tagIds;
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
@@ -1,0 +1,14 @@
+package com.bonheur.domain.board.model.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetBoardByTagRequest {
+    private Long memberId;
+    private List<Long> tagIds;
+}

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
@@ -14,17 +14,19 @@ public class GetBoardsResponse {
     private String contents;
     private List<String> boardTags;
     private String image; // 대표 이미지 url
+    private String createdAt;
 
-    private GetBoardsResponse(String contents, List<String> boardTags) {
+    private GetBoardsResponse(String contents, List<String> boardTags, String createdAt) {
         this.contents = contents;
         this.boardTags = boardTags;
+        this.createdAt = createdAt;
     }
 
-    public static GetBoardsResponse of(String contents, List<String> boardTags, String image) {
-        return new GetBoardsResponse(contents, boardTags, image);
+    public static GetBoardsResponse of(String contents, List<String> boardTags, String image, String createdAt) {
+        return new GetBoardsResponse(contents, boardTags, image, createdAt);
     }
 
-    public static GetBoardsResponse withoutImage(String contents, List<String> boardTags) {
-        return new GetBoardsResponse(contents, boardTags);
+    public static GetBoardsResponse withoutImage(String contents, List<String> boardTags, String createdAt) {
+        return new GetBoardsResponse(contents, boardTags, createdAt);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
@@ -1,0 +1,30 @@
+package com.bonheur.domain.board.model.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetBoardsResponse {
+    private String contents;
+    private List<String> boardTags;
+    private String image; // 대표 이미지 url
+
+    private GetBoardsResponse(String contents, List<String> boardTags) {
+        this.contents = contents;
+        this.boardTags = boardTags;
+    }
+
+    public static GetBoardsResponse of(String contents, List<String> boardTags, String image) {
+        return new GetBoardsResponse(contents, boardTags, image);
+    }
+
+    public static GetBoardsResponse withoutImage(String contents, List<String> boardTags) {
+        return new GetBoardsResponse(contents, boardTags);
+    }
+}

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
@@ -23,10 +23,7 @@ public class GetBoardsResponse {
     }
 
     public static GetBoardsResponse of(String contents, List<String> boardTags, String image, String createdAt) {
+        if (image == null) return new GetBoardsResponse(contents, boardTags, createdAt);
         return new GetBoardsResponse(contents, boardTags, image, createdAt);
-    }
-
-    public static GetBoardsResponse withoutImage(String contents, List<String> boardTags, String createdAt) {
-        return new GetBoardsResponse(contents, boardTags, createdAt);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
@@ -6,5 +6,6 @@ import org.springframework.data.domain.Slice;
 
 public interface BoardRepositoryCustom {
     Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, Pageable pageable);
+    Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, Long tagId, Pageable pageable);
     Board findBoardByIdWithTagAndImage(Long boardId);
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
@@ -4,8 +4,10 @@ import com.bonheur.domain.board.model.Board;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 public interface BoardRepositoryCustom {
     Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, Pageable pageable);
-    Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, Long tagId, Pageable pageable);
+    Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
     Board findBoardByIdWithTagAndImage(Long boardId);
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
@@ -1,7 +1,10 @@
 package com.bonheur.domain.board.repository;
 
 import com.bonheur.domain.board.model.Board;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface BoardRepositoryCustom {
+    Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, Pageable pageable);
     Board findBoardByIdWithTagAndImage(Long boardId);
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -1,12 +1,15 @@
 package com.bonheur.domain.board.repository;
 
 import com.bonheur.domain.board.model.Board;
+import com.bonheur.domain.board.model.QBoard;
+import com.bonheur.domain.boardtag.model.QBoardTag;
 import com.bonheur.domain.image.model.QImage;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import com.bonheur.domain.tag.model.QTag;
 import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -1,18 +1,57 @@
 package com.bonheur.domain.board.repository;
 
 import com.bonheur.domain.board.model.Board;
-import com.bonheur.domain.board.model.QBoard;
-import com.bonheur.domain.boardtag.model.QBoardTag;
 import com.bonheur.domain.image.model.QImage;
-import com.bonheur.domain.tag.model.QTag;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
 
 import static com.bonheur.domain.board.model.QBoard.board;
 
 @RequiredArgsConstructor
 public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    // # 게시글 전체 조회 (무한 스크롤, no-offset)
+    public Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, Pageable pageable) {
+        List<Board> results = queryFactory.selectFrom(board)
+                .where(
+                        // no-offset 페이징 처리
+                        ltBoardId(lastBoardId),
+                        // memberId
+                        board.member.id.eq(memberId)
+                ).orderBy(board.createdAt.desc())
+                .limit(pageable.getPageSize() + 1) // Slice 방식
+                .fetch();
+
+        // 무한 스크롤 처리
+        return checkLastPage(pageable, results);
+    }
+
+    // no-offset 방식 처리 (처음 조회시 boardId가 null로 들어옴)
+    private BooleanExpression ltBoardId(Long boardId) {
+        if (boardId == null) return null;
+        return board.id.lt(boardId);
+    }
+
+    // 무한 스크롤 방식 처리
+    private Slice<Board> checkLastPage(Pageable pageable, List<Board> results) {
+        boolean hasNext = false; // pagesize보다 1 크게 가져와서 다음 페이지가 남았는지 확인
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize()); // 필요없으므로 삭제
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
 
     @Override
     public Board findBoardByIdWithTagAndImage(Long boardId) {

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -1,7 +1,6 @@
 package com.bonheur.domain.board.repository;
 
 import com.bonheur.domain.board.model.Board;
-import com.bonheur.domain.board.model.QBoard;
 import com.bonheur.domain.boardtag.model.QBoardTag;
 import com.bonheur.domain.image.model.QImage;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -39,7 +38,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
 
     @Override
     // # 게시글 조회 - by TagName (무한 스크롤, no-offset)
-    public Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, Long tagId, Pageable pageable) {
+    public Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable) {
         QTag tag = QTag.tag;
         QBoardTag boardTag = QBoardTag.boardTag;
         List<Board> results = queryFactory.selectFrom(board)
@@ -50,7 +49,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
                         board.member.id.eq(memberId),
                         // tag
                         board.id.in(queryFactory.select(boardTag.board.id).from(boardTag)
-                                .where(tag.id.eq(tagId))
+                                .where(tag.id.in(tagIds))
                                 .leftJoin(tag).on(tag.id.eq(boardTag.tag.id))
                         )
                 )

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -1,19 +1,19 @@
 package com.bonheur.domain.board.repository;
 
 import com.bonheur.domain.board.model.Board;
-import com.bonheur.domain.boardtag.model.QBoardTag;
 import com.bonheur.domain.image.model.QImage;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import com.bonheur.domain.tag.model.QTag;
 import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
 import static com.bonheur.domain.board.model.QBoard.board;
+import static com.bonheur.domain.boardtag.model.QBoardTag.boardTag;
+import static com.bonheur.domain.tag.model.QTag.tag;
 
 @RequiredArgsConstructor
 public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
@@ -39,8 +39,6 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     @Override
     // # 게시글 조회 - by TagName (무한 스크롤, no-offset)
     public Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable) {
-        QTag tag = QTag.tag;
-        QBoardTag boardTag = QBoardTag.boardTag;
         List<Board> results = queryFactory.selectFrom(board)
                 .where(
                         // no-offset 페이징 처리

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public interface BoardService {
      Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable);
+     DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
      CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
      UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -14,6 +14,5 @@ public interface BoardService {
      Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
      CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
      UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
-
      GetBoardResponse getBoard(Long boardId);
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface BoardService {
      Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable);
      DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
-     Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, String tagName, Pageable pageable);
+     Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
      CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
      UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -11,6 +11,7 @@ import java.util.List;
 public interface BoardService {
      Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable);
      DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
+     Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, String tagName, Pageable pageable);
      CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
      UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -1,12 +1,15 @@
 package com.bonheur.domain.board.service;
 
 import com.bonheur.domain.board.model.dto.*;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
 
 public interface BoardService {
+     Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable);
      CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
      UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -63,13 +63,9 @@ public class BoardServiceImpl implements BoardService {
             imageService.deleteImagesIns3(board); // s3, 테이블에서 이미지 삭제
             boardRepository.delete(board); // board 삭제
 
-            return DeleteBoardResponse.builder()
-                    .boardId(boardId)
-                    .build();
+            return DeleteBoardResponse.of(boardId);
         } else {
-            return DeleteBoardResponse.builder()
-                    .boardId(null)
-                    .build();
+            return DeleteBoardResponse.of(null);
         }
     }
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -62,6 +62,25 @@ public class BoardServiceImpl implements BoardService {
         return tagsName;
     }
 
+    // # 게시글 삭제 (boardTag, Image의 cascadeType을 all로 설정해뒀기 때문에 게시글 삭제 시, boardTags와 images 삭제
+    // 회원 정보 인증 어노테이션 추가 필요
+    @Override
+    @Transactional
+    public DeleteBoardResponse deleteBoard(Long memberId, Long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(()-> new IllegalArgumentException("존재하지 않는 글입니다."));
+        Long writer = board.getMember().getId();
+        if (writer.equals(memberId)) {
+            boardRepository.delete(board);
+            return DeleteBoardResponse.builder()
+                    .boardId(boardId)
+                    .build();
+        } else {
+            return DeleteBoardResponse.builder()
+                    .boardId(null)
+                    .build();
+        }
+    }
+
     //게시글 생성
     @Override
     @Transactional

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -86,12 +86,8 @@ public class BoardServiceImpl implements BoardService {
     // 회원 정보 인증 어노테이션 추가 필요
     @Override
     @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, String tagName, Pageable pageable) {
-        // tagName에 해당하는 tagId 받아오기
-        Tag tag = tagRepository.findTagByName(tagName).orElseThrow(()-> new IllegalArgumentException("존재하지 않는 태그입니다."));
-        Long tagId = tag.getId();
-
-        return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagId, pageable)
+    public Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable) {
+        return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, pageable)
                 .map(board -> {
                     if (board.getImages().isEmpty()) {
                         return GetBoardsResponse.withoutImage(board.getContents(), getBoardTagsName(board.getBoardTags()));

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -71,7 +71,9 @@ public class BoardServiceImpl implements BoardService {
         Board board = boardRepository.findById(boardId).orElseThrow(()-> new IllegalArgumentException("존재하지 않는 글입니다."));
         Long writer = board.getMember().getId();
         if (writer.equals(memberId)) {
-            boardRepository.delete(board);
+            imageService.deleteImages(board);
+            boardRepository.delete(board); // board 삭제
+
             return DeleteBoardResponse.builder()
                     .boardId(boardId)
                     .build();
@@ -80,6 +82,18 @@ public class BoardServiceImpl implements BoardService {
                     .boardId(null)
                     .build();
         }
+    }
+
+    // # file path를 string으로 저장하는 함수
+    private List<String> getFilePaths(Board board) {
+        List<Image> images = board.getImages();
+        List<String> filePaths = new ArrayList<>();
+
+        for (Image img : images) {
+            filePaths.add(img.getPath());
+        }
+
+        return filePaths;
     }
 
     // # 게시글 조회 - by 해시태그

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,9 +44,11 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findAllWithPaging(lastBoardId, memberId, pageable)
                 .map(board -> {
                     if (board.getImages().isEmpty()) {
-                        return GetBoardsResponse.withoutImage(board.getContents(), getBoardTagsName(board.getBoardTags()));
+                        return GetBoardsResponse.withoutImage(board.getContents(), getBoardTagsName(board.getBoardTags()),
+                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
                     }   else {
-                        return GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()), board.getImages().get(0).getUrl());
+                        return GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()), board.getImages().get(0).getUrl(),
+                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
                     }
                 });
     }
@@ -90,9 +93,11 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, pageable)
                 .map(board -> {
                     if (board.getImages().isEmpty()) {
-                        return GetBoardsResponse.withoutImage(board.getContents(), getBoardTagsName(board.getBoardTags()));
+                        return GetBoardsResponse.withoutImage(board.getContents(), getBoardTagsName(board.getBoardTags()),
+                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
                     }   else {
-                        return GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()), board.getImages().get(0).getUrl());
+                        return GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()), board.getImages().get(0).getUrl(),
+                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
                     }
                 });
     }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -71,7 +71,7 @@ public class BoardServiceImpl implements BoardService {
         Board board = boardRepository.findById(boardId).orElseThrow(()-> new IllegalArgumentException("존재하지 않는 글입니다."));
         Long writer = board.getMember().getId();
         if (writer.equals(memberId)) {
-            imageService.deleteImages(board);
+            imageService.deleteImagesIns3(board); // s3, 테이블에서 이미지 삭제
             boardRepository.delete(board); // board 삭제
 
             return DeleteBoardResponse.builder()
@@ -82,18 +82,6 @@ public class BoardServiceImpl implements BoardService {
                     .boardId(null)
                     .build();
         }
-    }
-
-    // # file path를 string으로 저장하는 함수
-    private List<String> getFilePaths(Board board) {
-        List<Image> images = board.getImages();
-        List<String> filePaths = new ArrayList<>();
-
-        for (Image img : images) {
-            filePaths.add(img.getPath());
-        }
-
-        return filePaths;
     }
 
     // # 게시글 조회 - by 해시태그

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -7,14 +7,12 @@ import com.bonheur.domain.image.model.Image;
 import com.bonheur.domain.image.service.ImageService;
 import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.repository.MemberRepository;
-import com.bonheur.domain.tag.model.Tag;
 import com.bonheur.domain.tag.service.TagService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.bonheur.domain.boardtag.model.BoardTag;
-import com.bonheur.domain.tag.repository.TagRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +32,6 @@ public class BoardServiceImpl implements BoardService {
     private final MemberRepository memberRepository;
     private final TagService tagService;
     private final ImageService imageService;
-    private final TagRepository tagRepository;
 
     // # 게시글 전체 조회
     // 회원 정보 인증 어노테이션 추가 필요

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 
 import java.io.IOException;
@@ -39,28 +38,18 @@ public class BoardServiceImpl implements BoardService {
     @Transactional(readOnly = true)
     public Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable) {
         return boardRepository.findAllWithPaging(lastBoardId, memberId, pageable)
-                .map(board -> {
-                    if (board.getImages().isEmpty()) {
-                        return GetBoardsResponse.withoutImage(board.getContents(), getBoardTagsName(board.getBoardTags()),
-                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
-                    }   else {
-                        return GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()), board.getImages().get(0).getUrl(),
-                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
-                    }
-                });
+                .map(board -> GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()),
+                        board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")))
+                );
     }
 
     // # Tag Name을 String List로 받아오기
     @Transactional(readOnly = true)
     public List<String> getBoardTagsName(List<BoardTag> boardTags) {
-        List<String> tagsName = new ArrayList<>();
-
-        for (BoardTag tag : boardTags) {
-            String tagName = tag.getTag().getName();
-            tagsName.add(tagName);
-        }
-
-        return tagsName;
+        return boardTags.stream().map(
+                boardTag -> boardTag.getTag().getName())
+                .collect(Collectors.toList());
     }
 
     // # 게시글 삭제 (boardTag, Image의 cascadeType을 all로 설정해뒀기 때문에 게시글 삭제 시, boardTags와 images 삭제
@@ -90,15 +79,10 @@ public class BoardServiceImpl implements BoardService {
     @Transactional(readOnly = true)
     public Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable) {
         return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, pageable)
-                .map(board -> {
-                    if (board.getImages().isEmpty()) {
-                        return GetBoardsResponse.withoutImage(board.getContents(), getBoardTagsName(board.getBoardTags()),
-                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
-                    }   else {
-                        return GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()), board.getImages().get(0).getUrl(),
-                                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")));
-                    }
-                });
+                .map(board -> GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()),
+                        board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH:mm:ss")))
+                );
     }
 
     //게시글 생성
@@ -134,8 +118,6 @@ public class BoardServiceImpl implements BoardService {
         }
         return UpdateBoardResponse.newResponse(boardId);
     }
-
-
 
     @Override
     public GetBoardResponse getBoard(Long boardId) {

--- a/src/main/java/com/bonheur/domain/boardtag/repository/BoardTagRepository.java
+++ b/src/main/java/com/bonheur/domain/boardtag/repository/BoardTagRepository.java
@@ -2,12 +2,10 @@ package com.bonheur.domain.boardtag.repository;
 
 import com.bonheur.domain.board.model.Board;
 import com.bonheur.domain.boardtag.model.BoardTag;
-import com.bonheur.domain.tag.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BoardTagRepository extends JpaRepository<BoardTag,Long>,BoardTagRepositoryCustom {
     List<BoardTag> findAllByBoard(Board board);
-    List<BoardTag> findAllByTag(Tag tag);
 }

--- a/src/main/java/com/bonheur/domain/boardtag/service/BoardTagServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/boardtag/service/BoardTagServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,24 +20,18 @@ public class BoardTagServiceImpl implements BoardTagService{
     @Transactional
     public void createBoardTags(Board board, List<Long> tagsIds){    //게시글과 해시태그 맵핑(연결)
         for(Long tagId : tagsIds) {
-            Optional<Tag> tag = tagRepository.findById(tagId);
-            tag.orElseThrow(() -> new RuntimeException("존재하지 않은 태그입니다."));
-            boardTagRepository.save(BoardTag.newBoardTag(board, tag.get()));
+            Tag tag = tagRepository.findById(tagId).orElseThrow(() -> new RuntimeException("존재하지 않은 태그입니다."));
+            boardTagRepository.save(BoardTag.newBoardTag(board, tag));
         }
     }
 
     @Override
     @Transactional
     public void updateBoardTags(Board board, List<Long> tagIds){
-        List<BoardTag> boardTags = boardTagRepository.findAllByBoard(board); //기존 게시글 태그들
 
-        if(boardTags != null){
-            for(BoardTag boardTag : boardTags){
-                boardTagRepository.delete(boardTag);    //기존 게시글 태그 삭제
-            }
-        }
+        boardTagRepository.deleteAllInBatch(boardTagRepository.findAllByBoard(board));    //기존 게시글 태그 삭제
 
-        if(tagIds != null) {
+        if(!tagIds.isEmpty()) {
             createBoardTags(board, tagIds);    //게시글 새로운 태그 추가
         }
     }

--- a/src/main/java/com/bonheur/domain/boardtag/service/BoardTagServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/boardtag/service/BoardTagServiceImpl.java
@@ -28,8 +28,10 @@ public class BoardTagServiceImpl implements BoardTagService{
     @Override
     @Transactional
     public void updateBoardTags(Board board, List<Long> tagIds){
-
-        boardTagRepository.deleteAllInBatch(boardTagRepository.findAllByBoard(board));    //기존 게시글 태그 삭제
+        List<BoardTag> boardTags = boardTagRepository.findAllByBoard(board);
+        if(!boardTags.isEmpty()){
+            boardTagRepository.deleteAllInBatch(boardTags);    //기존 게시글 태그 삭제
+        }
 
         if(!tagIds.isEmpty()) {
             createBoardTags(board, tagIds);    //게시글 새로운 태그 추가

--- a/src/main/java/com/bonheur/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/bonheur/domain/image/repository/ImageRepository.java
@@ -1,10 +1,11 @@
 package com.bonheur.domain.image.repository;
 
+import com.bonheur.domain.board.model.Board;
 import com.bonheur.domain.image.model.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image,Long>,ImageRepositoryCustom {
-    List<Image> findAllByBoard_Id(Long boardId);
+    List<Image> findAllByBoard(Board board);
 }

--- a/src/main/java/com/bonheur/domain/image/service/ImageService.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageService.java
@@ -10,4 +10,6 @@ public interface ImageService {
     //이미지 업로드
     void uploadImages(Board board, List<MultipartFile> images) throws IOException;
     void updateImages(Board board, List<MultipartFile> images) throws IOException;
+
+    void deleteImages(Board board);
 }

--- a/src/main/java/com/bonheur/domain/image/service/ImageService.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageService.java
@@ -11,5 +11,5 @@ public interface ImageService {
     void uploadImages(Board board, List<MultipartFile> images) throws IOException;
     void updateImages(Board board, List<MultipartFile> images) throws IOException;
 
-    void deleteImages(Board board);
+    void deleteImagesIns3(Board board);
 }

--- a/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
@@ -47,15 +47,16 @@ public class ImageServiceImpl implements ImageService{
         uploadImages(board, images);            //새로운 이미지 업로드
     }
 
-    // # image s3에서 삭제
+    // # image s3, 테이블에서 삭제
     @Override
     @Transactional
-    public void deleteImages(Board board) {
+    public void deleteImagesIns3(Board board) {
         List<Image> toDeleteImages = imageRepository.findAllByBoard_Id(board.getId());
 
-        for (Image img : toDeleteImages) {
-            fileUploadUtil.deleteFile(img.getPath());
-            imageRepository.delete(img);
+        if (toDeleteImages != null) {
+            for (Image img : toDeleteImages) {
+                fileUploadUtil.deleteFile(img.getPath());
+            }
         }
     }
 }

--- a/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
@@ -46,4 +46,16 @@ public class ImageServiceImpl implements ImageService{
         }
         uploadImages(board, images);            //새로운 이미지 업로드
     }
+
+    // # image s3에서 삭제
+    @Override
+    @Transactional
+    public void deleteImages(Board board) {
+        List<Image> toDeleteImages = imageRepository.findAllByBoard_Id(board.getId());
+
+        for (Image img : toDeleteImages) {
+            fileUploadUtil.deleteFile(img.getPath());
+            imageRepository.delete(img);
+        }
+    }
 }

--- a/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
@@ -36,13 +36,11 @@ public class ImageServiceImpl implements ImageService{
     @Override
     @Transactional
     public void updateImages(Board board, List<MultipartFile> images) throws IOException{
-        List<Image> oldImages = imageRepository.findAllByBoard_Id(board.getId()); //기존 이미지 테이블에 있는 게시글 관련 이미지들
+        List<Image> oldImages = imageRepository.findAllByBoard(board); //기존 이미지 테이블에 있는 게시글 관련 이미지들
 
-        if(oldImages != null){
-            for(Image image : oldImages){
-                fileUploadUtil.deleteFile(image.getPath()); //s3에서 기존의 이미지 삭제
-                imageRepository.delete(image);          //기존의 이미지 삭제
-            }
+        if(!oldImages.isEmpty()){
+            oldImages.forEach(image -> fileUploadUtil.deleteFile(image.getPath())); //s3에서 기존의 이미지 삭제
+            imageRepository.deleteAllInBatch(oldImages);          //기존의 이미지 삭제
         }
         uploadImages(board, images);            //새로운 이미지 업로드
     }

--- a/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
@@ -37,7 +37,9 @@ public class ImageServiceImpl implements ImageService{
     @Transactional
     public void updateImages(Board board, List<MultipartFile> images) throws IOException{
         List<Image> oldImages = deleteImagesIns3(board);
-        imageRepository.deleteAllInBatch(oldImages);          //기존의 이미지 삭제
+        if(!oldImages.isEmpty()) {
+            imageRepository.deleteAllInBatch(oldImages);          //기존의 이미지 삭제
+        }
         uploadImages(board, images);            //새로운 이미지 업로드
     }
 

--- a/src/main/java/com/bonheur/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bonheur/domain/member/controller/MemberController.java
@@ -76,4 +76,11 @@ public class MemberController {
         return ApiResponse.success(memberService.findMyMonthRecord(memberId));
     }
 
+    @ApiDocumentResponse
+    @Operation(summary = "회원 최근 사용 태그 조회")
+    @GetMapping("/api/member/tags")
+    public ApiResponse<List<GetTagUsedByMemberResponse>> getTagUsedByMember() {
+        Long memberId = 1L;
+        return ApiResponse.success(memberService.getTagUsedByMember(memberId));
+    }
 }

--- a/src/main/java/com/bonheur/domain/member/model/dto/GetTagUsedByMemberResponse.java
+++ b/src/main/java/com/bonheur/domain/member/model/dto/GetTagUsedByMemberResponse.java
@@ -1,0 +1,18 @@
+package com.bonheur.domain.member.model.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetTagUsedByMemberResponse {
+    private Long tagId;
+    private String tagName;
+
+    public static GetTagUsedByMemberResponse of(Long tagId,String tagName) {
+        return new GetTagUsedByMemberResponse(tagId, tagName);
+    }
+}

--- a/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.bonheur.domain.member.repository;
 import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.model.MemberSocialType;
 import com.bonheur.domain.member.model.dto.*;
+import com.bonheur.domain.tag.model.Tag;
 
 import java.util.List;
 
@@ -19,4 +20,5 @@ public interface MemberRepositoryCustom {
     List<FindMonthRecordResponse> findMonthRecordByMemberId(Long memberId);
 
 
+    List<Tag> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.bonheur.domain.member.repository;
 import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.model.MemberSocialType;
 import com.bonheur.domain.member.model.dto.*;
+import com.bonheur.domain.tag.model.Tag;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.dsl.NumberOperation;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -13,6 +14,7 @@ import java.util.List;
 import static com.bonheur.domain.board.model.QBoard.board;
 import static com.bonheur.domain.boardtag.model.QBoardTag.boardTag;
 import static com.bonheur.domain.member.model.QMember.member;
+import static com.bonheur.domain.membertag.model.QMemberTag.memberTag;
 import static com.bonheur.domain.tag.model.QTag.tag;
 import static com.querydsl.core.types.Projections.*;
 import static com.querydsl.core.types.dsl.Expressions.numberOperation;
@@ -158,5 +160,20 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<Tag> getTagUsedByMember(Long memberId) {
+        return queryFactory.select(tag)
+                .from(tag)
+                .leftJoin(tag.memberTags,memberTag).fetchJoin()
+                .leftJoin(memberTag.member).fetchJoin()
+                .where(
+                        memberTag.member.id.eq(memberId)
+                )
+                .distinct()
+                .orderBy(memberTag.updatedAt.desc())
+                .offset(0)
+                .limit(5)
+                .fetch();
+    }
 }
 

--- a/src/main/java/com/bonheur/domain/member/service/MemberService.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberService.java
@@ -19,4 +19,6 @@ public interface MemberService {
 
     List<FindDayRecordResponse> findMyDayRecord(Long memberId);
     List<FindMonthRecordResponse> findMyMonthRecord(Long memberId);
+
+    List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -94,6 +94,12 @@ public class MemberServiceImpl implements MemberService{
     @Override
     @Transactional
     public List<FindMonthRecordResponse> findMyMonthRecord(Long memberId) { return memberRepository.findMonthRecordByMemberId(memberId); }
+
+    @Override
+    @Transactional
+    public List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId) {
+        return memberRepository.getTagUsedByMember(memberId).stream().map(tag -> GetTagUsedByMemberResponse.of(tag.getId(),tag.getName())).collect(Collectors.toList());
+    }
 }
 
 

--- a/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepository.java
+++ b/src/main/java/com/bonheur/domain/membertag/repository/MemberTagRepository.java
@@ -1,8 +1,12 @@
 package com.bonheur.domain.membertag.repository;
 
 import com.bonheur.domain.membertag.model.MemberTag;
+import com.bonheur.domain.tag.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 
 public interface MemberTagRepository extends JpaRepository<MemberTag,Long>, MemberTagRepositoryCustom {
+    Optional<MemberTag> findMemberTagByTag(Tag tag);
 }

--- a/src/main/java/com/bonheur/domain/membertag/service/MemberTagService.java
+++ b/src/main/java/com/bonheur/domain/membertag/service/MemberTagService.java
@@ -1,9 +1,10 @@
 package com.bonheur.domain.membertag.service;
 
 import com.bonheur.domain.member.model.Member;
+import com.bonheur.domain.tag.model.Tag;
 
 import java.util.List;
 
 public interface MemberTagService {
-    void createMemberTags(Member member, List<Long> tagIds);
+    void createMemberTags(Member member, List<Tag> tags);
 }

--- a/src/main/java/com/bonheur/domain/membertag/service/MemberTagServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/membertag/service/MemberTagServiceImpl.java
@@ -4,7 +4,6 @@ import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.membertag.model.MemberTag;
 import com.bonheur.domain.membertag.repository.MemberTagRepository;
 import com.bonheur.domain.tag.model.Tag;
-import com.bonheur.domain.tag.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,20 +16,19 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MemberTagServiceImpl implements MemberTagService {
     private final MemberTagRepository memberTagRepository;
-    private final TagRepository tagRepository;
 
     @Override
     @Transactional
-    public void createMemberTags(Member member, List<Long> tagsIds){    //태그와 사용자 맵핑(연결)
-        for(Long tagId : tagsIds) {
-            Tag tag = tagRepository.findTagById(tagId);
-            Optional<MemberTag> memberTag = memberTagRepository.findById(tagId);
-            if(memberTag.isEmpty()){
-                memberTagRepository.save(MemberTag.newMemberTag(member, tag));
+    public void createMemberTags(Member member, List<Tag> tags){    //태그와 사용자 맵핑(연결)
+        tags.forEach(tag -> {
+                Optional<MemberTag> memberTag = memberTagRepository.findMemberTagByTag(tag);
+                if(memberTag.isEmpty()){
+                    memberTagRepository.save(MemberTag.newMemberTag(member, tag));
+                }
+                else{
+                    memberTag.get().updateUpdatedAt(LocalDateTime.now());
+                }
             }
-            else{
-                memberTag.get().updateUpdatedAt(LocalDateTime.now());
-            }
-        }
+        );
     }
 }

--- a/src/main/java/com/bonheur/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/bonheur/domain/tag/repository/TagRepository.java
@@ -7,5 +7,4 @@ import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag,Long>,TagRepositoryCustom {
     Optional<Tag> findTagByName(String name); //태그 이름으로 해당 tag 찾기
-    Tag findTagById(Long id);
 }


### PR DESCRIPTION
## 개요
`feature/board-create-edit-#80`에 해당 (#80) 

## 작업사항_Merge 충돌 해결
- [x]  Merge 충돌 해결 : BoardController, BoardService, ImageService
- [x] 공통부분 수정 : deleteImagesIns3
- 게시글 수정 부분에서 이미지를 삭제하는 함수가 develop에 구현된 deleteImagesIns3와 거의 동일하여, 
반환값을 void에서 List<Image>로 변경하여 updateImages에서도 사용할 수 있도록 함!

## 작업사항_Tag 관련 코드 Refactor
- [x] Service 코드 수정 : createTags, createMemberTags
- for문을 forEach로 변경 및 orElseGet()함수를 사용하여 코드 간결화
- createMemberTags로 TagIds가 아닌 Tag를 넘겨주는 방식으로 변경 (피드백 반영)
- [x] 사용하지 않는 코드 삭제 : findTagById

## 작업사항_Board 관련 코드 Refactor
- [x] updateBoard에서 request.getContents().isEmpty() 삭제
- 이미 request에서 @NotBlank를 사용하여 체크하고 있으므로 해당 부분 삭제
- [x] orElseThrow() 함수 사용
- [x] 기존에 for문을 사용한 delete를 deleteAllInBatch() 함수로 변경