### PR TITLE
[Fix] 게시물 상세조회 API 수정

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -125,10 +125,11 @@ public class BoardController {
     @Operation(summary = "게시물 상세 조회")
     // 이상 Swagger 코드
     @GetMapping("/api/boards/{boardId}")
+    @Auth
     public ApiResponse<GetBoardResponse> getBoard(
             @PathVariable Long boardId,
-            Long memberId
+            @Valid @MemberId Long memberId
     ) {
-        return ApiResponse.success(boardService.getBoard(boardId));
+        return ApiResponse.success(boardService.getBoard(memberId, boardId));
     }
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface BoardRepositoryCustom {
     Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, Pageable pageable);
     Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
-    Board findBoardByIdWithTagAndImage(Long boardId);
+    Board findBoardByIdWithMemberAndImages(Long boardId);
     List<Integer> getCalendar(Long memberId, int year, int month, int lastDay);
     Slice<Board> findByCreatedAtWithPaging(Long lastBoardId, Long memberId, LocalDate localDate, Pageable pageable);
     Long getNumOfBoardsByDate(Long memberId, LocalDate localDate);

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.bonheur.domain.board.repository;
 
 import com.bonheur.domain.board.model.Board;
 import com.bonheur.domain.image.model.QImage;
+import com.bonheur.domain.member.model.QMember;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberOperation;
@@ -17,6 +18,8 @@ import java.util.List;
 
 import static com.bonheur.domain.board.model.QBoard.board;
 import static com.bonheur.domain.boardtag.model.QBoardTag.boardTag;
+import static com.bonheur.domain.image.model.QImage.image;
+import static com.bonheur.domain.member.model.QMember.member;
 import static com.bonheur.domain.tag.model.QTag.tag;
 import static com.querydsl.core.types.dsl.Expressions.numberOperation;
 
@@ -74,7 +77,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
                 .where(
                         // no-offset 페이징 처리
                         ltBoardId(lastBoardId),
-                        // memeberId
+                        // memberId
                         board.member.id.eq(memberId),
                         // createdAt
                         toYear.eq(localDate.getYear()),
@@ -136,7 +139,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
         return queryFactory.select(board.count())
                 .from(board)
                 .where(
-                        // memeberId
+                        // memberId
                         board.member.id.eq(memberId),
                         // createdAt
                         toYear.eq(localDate.getYear()),
@@ -146,10 +149,12 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     }
 
     @Override
-    public Board findBoardByIdWithTagAndImage(Long boardId) {
+    public Board findBoardByIdWithMemberAndImages(Long boardId) {
         return queryFactory.select(board)
                 .from(board)
-                .leftJoin(board.images,QImage.image)
+                .leftJoin(board.images, image)
+                .fetchJoin()
+                .leftJoin(board.member, member)
                 .fetchJoin()
                 .where(
                         board.id.eq(boardId)

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -10,14 +10,23 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface BoardService {
-     Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable);
-     DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
-     Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
-     CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
-     UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
-     GetBoardResponse getBoard(Long boardId);
-     GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice);
-     List<GetCalendarResponse> getCalendar(Long memberId, int year, int month);
-     Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, Pageable pageable);
-     Long getNumOfBoardsByDate(Long memberId, LocalDate localDate);
+    Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable);
+
+    DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
+
+    Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
+
+    CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
+
+    UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException;
+
+    GetBoardResponse getBoard(Long memberId, Long boardId);
+
+    GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice);
+
+    List<GetCalendarResponse> getCalendar(Long memberId, int year, int month);
+
+    Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, Pageable pageable);
+
+    Long getNumOfBoardsByDate(Long memberId, LocalDate localDate);
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -164,12 +164,15 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional
-    public GetBoardResponse getBoard(Long boardId) {
-        Board board = boardRepository.findBoardByIdWithTagAndImage(boardId);
+    public GetBoardResponse getBoard(Long memberId, Long boardId) {
+        Board board = boardRepository.findBoardByIdWithMemberAndImages(boardId);
+        /*
+          회원 검증 로직 추가 ( member.id == board.member.id )
+         */
         return GetBoardResponse.of(board.getId(), board.getContents(),
                 board.getImages().stream().map(Image::getUrl).collect(Collectors.toList()),
                 board.getBoardTags().stream().map(boardTag -> boardTag.getTag().getName()).collect(Collectors.toList()),
-                board.getCreatedAt().format(DateTimeFormatter.ofPattern("YYYY.MM.DD E요일 ").withLocale(Locale.KOREA))
+                board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd E요일 ").withLocale(Locale.KOREA))
         + board.getCreatedAt().format(DateTimeFormatter.ofPattern("ahh:mm").withLocale(Locale.ENGLISH)));
     }
 }


### PR DESCRIPTION
#134 

## 작업사항
- 게시물 상세 조회 시, 회원 ID 넘겨주도록 수정
- Repository에서 member 테이블도 조인하도록 수정

## 추후 작업 사항
- 회원 검증 로직 필요