### PR TITLE
[Fix] orderType 파라미터 추가로 "게시글 조회" 정렬순 선택

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -50,7 +50,6 @@ public class BoardController {
     }
 
     // # 게시글 조회 - 해시태그
-    /*
     @ApiDocumentResponse
     @Operation(summary = "행복기록 조회 - 해시태그")
     @ResponseBody
@@ -59,11 +58,11 @@ public class BoardController {
     public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(
             @RequestParam(required = false) Long lastBoardId,
             @Valid @MemberId Long memberId,
-            @RequestBody GetBoardByTagRequest getBoardByTagRequest,
+            @RequestBody GetBoardByTagRequest getBoardByTagRequest, @RequestParam(defaultValue = "newest") String orderType,
             @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
-                boardService.getBoardsByTag(lastBoardId, memberId, getBoardByTagRequest.getTagIds(), pageable);
-        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses);
+                boardService.getBoardsByTag(lastBoardId, memberId, getBoardByTagRequest.getTagIds(), orderType, pageable);
+        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, orderType);
 
         return ApiResponse.success(getBoardsGroupsResponse);
     }
@@ -76,13 +75,14 @@ public class BoardController {
     public ApiResponse<GetBoardsByDateResponse> getBoardsByDate(@Valid @MemberId Long memberId,
                                                                 @RequestParam(required = false) Long lastBoardId,
                                                                 @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate,
+                                                                @RequestParam(defaultValue = "newest") String orderType,
                                                                 Pageable pageable) {
-        Slice<GetBoardsResponse> getBoardsResponses = boardService.getBoardsByDate(memberId, lastBoardId,localDate, pageable);
+        Slice<GetBoardsResponse> getBoardsResponses = boardService.getBoardsByDate(memberId, lastBoardId,localDate, orderType, pageable);
         Long count = boardService.getNumOfBoardsByDate(memberId, localDate);
 
         GetBoardsByDateResponse getBoardsByDateResponse = GetBoardsByDateResponse.of(count, getBoardsResponses);
         return ApiResponse.success(getBoardsByDateResponse);
-    }*/
+    }
 
     // # 캘린더 화면
     @ApiDocumentResponse

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -31,10 +31,10 @@ public class BoardController {
     @GetMapping("/api/boards")
     @Auth
     public ApiResponse<GetBoardsGroupsResponse> getAllBoards(@RequestParam(required = false) Long lastBoardId,
-                                                             @Valid @MemberId Long memberId,
+                                                             @Valid @MemberId Long memberId, @RequestParam(defaultValue = "newest") String orderType,
                                                              @PageableDefault(size = 5) Pageable pageable) {
-        Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, pageable);
-        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses);
+        Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, orderType, pageable);
+        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, orderType);
 
         return ApiResponse.success(getBoardsGroupsResponse);
     }
@@ -50,6 +50,7 @@ public class BoardController {
     }
 
     // # 게시글 조회 - 해시태그
+    /*
     @ApiDocumentResponse
     @Operation(summary = "행복기록 조회 - 해시태그")
     @ResponseBody
@@ -81,7 +82,7 @@ public class BoardController {
 
         GetBoardsByDateResponse getBoardsByDateResponse = GetBoardsByDateResponse.of(count, getBoardsResponses);
         return ApiResponse.success(getBoardsByDateResponse);
-    }
+    }*/
 
     // # 캘린더 화면
     @ApiDocumentResponse

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
@@ -18,20 +18,12 @@ public class GetBoardsGroupsResponse {
     private String orderType; // newest : 최신, oldest : 오래된 순
 
     public static GetBoardsGroupsResponse of(Map<String, List<GetBoardsResponse>> group, String orderType) {
-        if (orderType.equals("newest")) {
-            group = group.entrySet().stream().sorted(Map.Entry.<String, List<GetBoardsResponse>>comparingByKey().reversed()).collect(Collectors.toMap(
-                    Map.Entry::getKey, Map.Entry::getValue,
-                    (e1, e2) -> e1,
-                    LinkedHashMap::new
-            ));
-        }
-        else {
-            group = group.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toMap(
-                    Map.Entry::getKey, Map.Entry::getValue,
-                    (e1, e2) -> e1,
-                    LinkedHashMap::new
-            ));
-        }
+        group = group.entrySet().stream().sorted(
+                orderType.equals("newest") ? Map.Entry.<String, List<GetBoardsResponse>>comparingByKey().reversed()
+                        : Map.Entry.comparingByKey()).collect(Collectors.toMap(
+                        Map.Entry::getKey, Map.Entry::getValue,
+                        (e1, e2) -> e1,
+                        LinkedHashMap::new));
         return new GetBoardsGroupsResponse(group, orderType);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
@@ -5,15 +5,33 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardsGroupsResponse {
     private Map<String, List<GetBoardsResponse>> group;
-    public static GetBoardsGroupsResponse of(Map<String, List<GetBoardsResponse>> group) {
-        return new GetBoardsGroupsResponse(group);
+    private String orderType; // newest : 최신, oldest : 오래된 순
+
+    public static GetBoardsGroupsResponse of(Map<String, List<GetBoardsResponse>> group, String orderType) {
+        if (orderType.equals("newest")) {
+            group = group.entrySet().stream().sorted(Map.Entry.<String, List<GetBoardsResponse>>comparingByKey().reversed()).collect(Collectors.toMap(
+                    Map.Entry::getKey, Map.Entry::getValue,
+                    (e1, e2) -> e1,
+                    LinkedHashMap::new
+            ));
+        }
+        else {
+            group = group.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toMap(
+                    Map.Entry::getKey, Map.Entry::getValue,
+                    (e1, e2) -> e1,
+                    LinkedHashMap::new
+            ));
+        }
+        return new GetBoardsGroupsResponse(group, orderType);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsResponse.java
@@ -11,13 +11,14 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardsResponse {
+    private Long boardId;
     private String contents;
     private List<String> boardTags;
     private String image; // 대표 이미지 url
     private String createdAtDate; // 형식 : 00월 00일 0요일
     private String createdAtTime; // 형식 : 0M 00:00
 
-    public static GetBoardsResponse of(String contents, List<String> boardTags, String image, String createdAtDate, String createdAtTime) {
-        return new GetBoardsResponse(contents, boardTags, image, createdAtDate, createdAtTime);
+    public static GetBoardsResponse of(Long boardId, String contents, List<String> boardTags, String image, String createdAtDate, String createdAtTime) {
+        return new GetBoardsResponse(boardId, contents, boardTags, image, createdAtDate, createdAtTime);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
@@ -8,10 +8,10 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface BoardRepositoryCustom {
-    Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, Pageable pageable);
-    Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
+    Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, String orderType, Pageable pageable);
+    Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, String orderType, Pageable pageable);
     Board findBoardByIdWithMemberAndImages(Long boardId);
     List<Integer> getCalendar(Long memberId, int year, int month, int lastDay);
-    Slice<Board> findByCreatedAtWithPaging(Long lastBoardId, Long memberId, LocalDate localDate, Pageable pageable);
+    Slice<Board> findByCreatedAtWithPaging(Long lastBoardId, Long memberId, LocalDate localDate, String orderType, Pageable pageable);
     Long getNumOfBoardsByDate(Long memberId, LocalDate localDate);
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -120,7 +120,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     public List<Integer> getCalendar(Long memberId, int year, int month, int lastDay) {
         NumberOperation<Integer> toDay = numberOperation(Integer.class, Ops.DateTimeOps.DAY_OF_MONTH, board.createdAt);
         LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0, 0);
-        LocalDateTime end = LocalDateTime.of(year, month, lastDay, 23, 59, 59);
+        LocalDateTime end = LocalDateTime.of(year, month, lastDay, 23, 59, 59, 999999999);
 
         return queryFactory.select(toDay).from(board)
                 .where(

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -1,8 +1,8 @@
 package com.bonheur.domain.board.repository;
 
 import com.bonheur.domain.board.model.Board;
+import com.bonheur.util.OrderSpecifierUtil;
 import com.querydsl.core.types.Ops;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberOperation;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -25,18 +25,20 @@ import static com.querydsl.core.types.dsl.Expressions.numberOperation;
 @RequiredArgsConstructor
 public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     private final JPAQueryFactory queryFactory;
+    private final NumberOperation<Integer> toYear = numberOperation(Integer.class, Ops.DateTimeOps.YEAR, board.createdAt);
+    private final NumberOperation<Integer> toMonth = numberOperation(Integer.class, Ops.DateTimeOps.MONTH, board.createdAt);
+    private final NumberOperation<Integer> toDay = numberOperation(Integer.class, Ops.DateTimeOps.DAY_OF_MONTH, board.createdAt);
 
     @Override
     // # 게시글 전체 조회 (무한 스크롤, no-offset)
     public Slice<Board> findAllWithPaging(Long lastBoardId, Long memberId, String orderType, Pageable pageable) {
-        OrderSpecifier<?> orderSpecifier = orderType.equals("newest") ? board.createdAt.desc() : board.createdAt.asc();
         List<Board> results = queryFactory.selectFrom(board)
                 .where(
                         // no-offset 페이징 처리
                         ltBoardId(lastBoardId, orderType),
                         // memberId
                         board.member.id.eq(memberId)
-                ).orderBy(orderSpecifier)
+                ).orderBy(OrderSpecifierUtil.getOrderSpecifier(orderType))
                 .limit(pageable.getPageSize() + 1) // Slice 방식
                 .fetch();
 
@@ -47,7 +49,6 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     @Override
     // # 게시글 조회 - by Tag (무한 스크롤, no-offset)
     public Slice<Board> findByTagWithPaging(Long lastBoardId, Long memberId, List<Long> tagIds, String orderType, Pageable pageable) {
-        OrderSpecifier<?> orderSpecifier = orderType.equals("newest") ? board.createdAt.desc() : board.createdAt.asc();
         List<Board> results = queryFactory.selectFrom(board)
                 .where(
                         // no-offset 페이징 처리
@@ -60,7 +61,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
                                 .leftJoin(tag).on(tag.id.eq(boardTag.tag.id))
                         )
                 )
-                .orderBy(orderSpecifier)
+                .orderBy(OrderSpecifierUtil.getOrderSpecifier(orderType))
                 .limit(pageable.getPageSize() + 1) // Slice 방식
                 .fetch();
 
@@ -71,10 +72,6 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     // # 게시글 조회 - 날짜별
     @Override
     public Slice<Board> findByCreatedAtWithPaging(Long lastBoardId, Long memberId, LocalDate localDate, String orderType, Pageable pageable) {
-        OrderSpecifier<?> orderSpecifier = orderType.equals("newest") ? board.createdAt.desc() : board.createdAt.asc();
-        NumberOperation<Integer> toYear = numberOperation(Integer.class, Ops.DateTimeOps.YEAR, board.createdAt);
-        NumberOperation<Integer> toMonth = numberOperation(Integer.class, Ops.DateTimeOps.MONTH, board.createdAt);
-        NumberOperation<Integer> toDay = numberOperation(Integer.class, Ops.DateTimeOps.DAY_OF_MONTH, board.createdAt);
         List<Board> results = queryFactory.selectFrom(board)
                 .where(
                         // no-offset 페이징 처리
@@ -86,7 +83,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
                         toMonth.eq(localDate.getMonthValue()),
                         toDay.eq(localDate.getDayOfMonth())
                 )
-                .orderBy(orderSpecifier)
+                .orderBy(OrderSpecifierUtil.getOrderSpecifier(orderType))
                 .limit(pageable.getPageSize() + 1) // Slice 방식
                 .fetch();
 
@@ -118,7 +115,6 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     @Override
     // # 캘린더 조회
     public List<Integer> getCalendar(Long memberId, int year, int month, int lastDay) {
-        NumberOperation<Integer> toDay = numberOperation(Integer.class, Ops.DateTimeOps.DAY_OF_MONTH, board.createdAt);
         LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0, 0);
         LocalDateTime end = LocalDateTime.of(year, month, lastDay, 23, 59, 59, 999999999);
 
@@ -136,10 +132,6 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
     // # 게시글 날짜별 조회 count
     @Override
     public Long getNumOfBoardsByDate(Long memberId, LocalDate localDate) {
-        NumberOperation<Integer> toYear = numberOperation(Integer.class, Ops.DateTimeOps.YEAR, board.createdAt);
-        NumberOperation<Integer> toMonth = numberOperation(Integer.class, Ops.DateTimeOps.MONTH, board.createdAt);
-        NumberOperation<Integer> toDay = numberOperation(Integer.class, Ops.DateTimeOps.DAY_OF_MONTH, board.createdAt);
-
         return queryFactory.select(board.count())
                 .from(board)
                 .where(

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -10,11 +10,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface BoardService {
-    Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable);
+    Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, String orderType, Pageable pageable);
 
     DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
 
-    Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable);
+    Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, String orderType, Pageable pageable);
 
     CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
 
@@ -22,11 +22,11 @@ public interface BoardService {
 
     GetBoardResponse getBoard(Long memberId, Long boardId);
 
-    GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice);
+    GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice, String orderType);
 
     List<GetCalendarResponse> getCalendar(Long memberId, int year, int month);
 
-    Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, Pageable pageable);
+    Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, String orderType, Pageable pageable);
 
     Long getNumOfBoardsByDate(Long memberId, LocalDate localDate);
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -14,15 +14,13 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
+import java.util.*;
+
 import com.bonheur.domain.boardtag.model.BoardTag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.time.format.DateTimeFormatter;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 @Service
@@ -37,9 +35,9 @@ public class BoardServiceImpl implements BoardService {
     // 회원 정보 인증 어노테이션 추가 필요
     @Override
     @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, Pageable pageable) {
-        return boardRepository.findAllWithPaging(lastBoardId, memberId, pageable)
-                .map(board -> GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()),
+    public Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, String orderType, Pageable pageable) {
+        return boardRepository.findAllWithPaging(lastBoardId, memberId, orderType, pageable)
+                .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
@@ -49,9 +47,10 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     // # 날짜별 그룹화
-    public GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice) {
+    public GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice, String orderType) {
         List<GetBoardsResponse> getBoardsResponsesOfSlice = getBoardsResponseSlice.getContent();
-        return GetBoardsGroupsResponse.of(getBoardsResponsesOfSlice.stream().collect(Collectors.groupingBy(GetBoardsResponse::getCreatedAtDate)));
+        return GetBoardsGroupsResponse.of(getBoardsResponsesOfSlice.stream().
+                collect(Collectors.groupingBy(GetBoardsResponse::getCreatedAtDate)), orderType);
     }
 
     // # Tag Name을 String List로 받아오기
@@ -83,9 +82,9 @@ public class BoardServiceImpl implements BoardService {
     // 회원 정보 인증 어노테이션 추가 필요
     @Override
     @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, Pageable pageable) {
-        return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, pageable)
-                .map(board -> GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()),
+    public Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, String orderType, Pageable pageable) {
+        return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, orderType, pageable)
+                .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
@@ -96,9 +95,9 @@ public class BoardServiceImpl implements BoardService {
     // 회원 정보 인증 어노테이션 추가 필요
     @Override
     @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, Pageable pageable) {
-        return boardRepository.findByCreatedAtWithPaging(lastBoardId, memberId, localDate, pageable)
-                .map(board -> GetBoardsResponse.of(board.getContents(), getBoardTagsName(board.getBoardTags()),
+    public Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, String orderType, Pageable pageable) {
+        return boardRepository.findByCreatedAtWithPaging(lastBoardId, memberId, localDate, orderType, pageable)
+                .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -39,7 +39,7 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findAllWithPaging(lastBoardId, memberId, orderType, pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
-                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
                 );
     }
@@ -86,7 +86,7 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, orderType, pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
-                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
                 );
     }
@@ -99,7 +99,7 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findByCreatedAtWithPaging(lastBoardId, memberId, localDate, orderType, pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
-                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일")),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
                 );
     }

--- a/src/main/java/com/bonheur/util/OrderSpecifierUtil.java
+++ b/src/main/java/com/bonheur/util/OrderSpecifierUtil.java
@@ -1,0 +1,16 @@
+package com.bonheur.util;
+
+import com.querydsl.core.types.OrderSpecifier;
+import org.springframework.stereotype.Component;
+
+import static com.bonheur.domain.board.model.QBoard.board;
+
+@Component
+public class OrderSpecifierUtil {
+    public static OrderSpecifier<?> getOrderSpecifier(String orderType) {
+        OrderSpecifier<?> orderSpecifier = orderType.equals("newest") ? board.createdAt.desc()
+                : board.createdAt.asc();
+
+        return orderSpecifier;
+    }
+}


### PR DESCRIPTION
## ✔️ 개요
#145 

## ✔️ 작업 사항 : 게시글 **조회** (전체, 태그별, 날짜별)
### Controller
게시글 조회에 ``@RequestParam(default = "newest") orderType`` 추가

### DTO(``GetBoardsGroupResponse``) 수정
그룹화된 Map도 ``orderType``에 따라 정렬될 수 있도록

### Service
- 게시글 조회에 ``orderType`` 추가
- created_at 날짜 파트 포맷 변경(정렬 문제로 인해)

| 수정 전|수정 후|
|:---------:|:------:|
|``MM월 dd일 E요일``|``yyyy년 MM월 dd일 E요일``|

### Repository
- 게시글 조회에 ``orderType`` 추가
- ``orderType``에 따라 정렬될 수 있도록 ``orderSpecifier`` 설정
- 날짜별 조회에서 end 값 변경

| 수정 전|수정 후|
|:---------:|:------:|
|``LocalDateTime.of(year, month, lastDay, 23, 59, 59)``|``LocalDateTime.of(year, month, lastDay, 23, 59, 59, 999999999)``|

## ✔️ Response
[Notion에 정리해뒀어요 누르면 넘어감](https://elite-daffodil-a3e.notion.site/Response-b3bc11d7b4b94de98947b6637d5453d2)