### PR TITLE
[Feat] request dto validation 추가 

### DIFF
--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
@@ -4,10 +4,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardByTagRequest {
+    @NotBlank
     private List<Long> tagIds;
 }


### PR DESCRIPTION
Issue Number #164

## 작업내용
태그별 행복 조회 시 사용되는 `GetBoardByTagRequest`에 @NotBlank 어노테이션을 추가했습니다.