### PR TITLE
[Feat] dto validation 어노테이션 추가 

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -58,7 +58,7 @@ public class BoardController {
     public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(
             @RequestParam(required = false) Long lastBoardId,
             @Valid @MemberId Long memberId,
-            @RequestBody GetBoardByTagRequest getBoardByTagRequest, @RequestParam(defaultValue = "newest") String orderType,
+            @Valid @RequestBody GetBoardByTagRequest getBoardByTagRequest, @RequestParam(defaultValue = "newest") String orderType,
             @PageableDefault(size = 5) Pageable pageable) {
         Slice<GetBoardsResponse> getBoardsResponses =
                 boardService.getBoardsByTag(lastBoardId, memberId, getBoardByTagRequest.getTagIds(), orderType, pageable);

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
@@ -4,12 +4,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardByTagRequest {
-    @NotBlank
+    @NotEmpty(message = "태그 아이디를 입력해주세요.")
     private List<Long> tagIds;
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
@@ -4,10 +4,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardByTagRequest {
+    @NotBlank
     private List<Long> tagIds;
 }


### PR DESCRIPTION
Issue Number #164 
<br>
## 작업내용
태그별 행복 조회 시 사용되는 `GetBoardByTagRequest`에 `@NotEmpty` 어노테이션을 추가했습니다.
<br>

## 실행 결과
<img width="857" alt="스크린샷 2023-02-08 오후 10 52 49" src="https://user-images.githubusercontent.com/78026977/217550686-80579c2d-d350-496c-b2f6-dcb2661152cc.png">
<img width="938" alt="스크린샷 2023-02-08 오후 11 00 01" src="https://user-images.githubusercontent.com/78026977/217551017-f21aff8d-1190-42fb-9e3c-8f5912f7ca17.png">


