### PR TITLE
fix : validateImageCount 함수 로직 변경

### DIFF
--- a/src/main/java/com/bonheur/domain/image/service/ImageServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageServiceHelper.java
@@ -12,8 +12,7 @@ import static com.bonheur.domain.common.exception.dto.ErrorCode.*;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageServiceHelper {
     public static void validateImageCount(List<MultipartFile> images, Long limit) {
-        Long imagesCount = images.stream().filter(image -> !image.isEmpty()).count();
-        if(imagesCount > limit){
+        if(images.size() > limit){
             throw new InvalidException("업로드 가능한 파일 개수를 초과했습니다", E400_INVALID_FILE_COUNT_TOO_MANY);
         }
     }


### PR DESCRIPTION
- for문 사용하여 이미지 개수 구하지 않고, list의 size() 사용
- `List<MultipartFile>` 타입의 경우, 파일을 첨부하지 않거나 파일이 1개인 경우 리스트의 크기(list.size())가 1로 잡힘.
- 따라서 이를 방지하고자 이전에는 for문을 사용하여 이미지 개수를 구함.
- 그러나, 이미지의 개수 제한이 0개인 경우가 없어서 list.size()를 사용해도 된다. -> list.size()가 for문 보다 더 빠르게 구할 수 있다.
(파일 개수 제한이 0개인 경우, `List<MultipartFile>` 타입을 아예 사용하지 않음)