### PR TITLE
[Feat] 게시글 전체 조회, 게시글 태그별 조회 예외 처리

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -49,21 +49,20 @@ public class BoardController {
     }
 
     // # 게시글 조회 - 해시태그
-//    @ApiDocumentResponse
-//    @Operation(summary = "행복기록 조회 - 해시태그")
-//    @ResponseBody
-//    @PostMapping ("/api/boards/tag")
-//    @Auth
-//    public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(@Valid @MemberId Long memberId,
-//                                                               @RequestBody GetBoardsRequest request,
-//                                                               @RequestBody GetBoardByTagRequest tagRequest,
-//                                                               @PageableDefault(size = 5) Pageable pageable) {
-//        Slice<GetBoardsResponse> getBoardsResponses =
-//                boardService.getBoardsByTag(memberId, request, tagRequest.getTagIds(), pageable);
-//        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, request.getOrderType()));
-//
-//        return ApiResponse.success(getBoardsGroupsResponse);
-//    }
+    @ApiDocumentResponse
+    @Operation(summary = "행복기록 조회 - 해시태그")
+    @ResponseBody
+    @PostMapping ("/api/boards/tag")
+    @Auth
+    public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(@Valid @MemberId Long memberId,
+                                                               @RequestBody GetBoardByTagRequest tagRequest,
+                                                               @PageableDefault(size = 5) Pageable pageable) {
+        Slice<GetBoardsResponse> getBoardsResponses =
+                boardService.getBoardsByTag(memberId, tagRequest.getRequest(), tagRequest.getTagIds(), pageable);
+        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, tagRequest.getRequest().getOrderType());
+
+        return ApiResponse.success(getBoardsGroupsResponse);
+    }
 
     // # 게시글 조회 - by 날짜
     @ApiDocumentResponse

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -57,9 +57,10 @@ public class BoardController {
     public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(@Valid @MemberId Long memberId,
                                                                @RequestBody GetBoardByTagRequest tagRequest,
                                                                @PageableDefault(size = 5) Pageable pageable) {
+        GetBoardsRequest getBoardsRequest = GetBoardsRequest.of(tagRequest.getOrderType(), tagRequest.getLastBoardId());
         Slice<GetBoardsResponse> getBoardsResponses =
-                boardService.getBoardsByTag(memberId, tagRequest.getRequest(), tagRequest.getTagIds(), pageable);
-        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, tagRequest.getRequest().getOrderType());
+                boardService.getBoardsByTag(memberId, getBoardsRequest, tagRequest, pageable);
+        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, getBoardsRequest.getOrderType());
 
         return ApiResponse.success(getBoardsGroupsResponse);
     }

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -25,16 +25,15 @@ import java.util.List;
 public class BoardController {
     private final BoardService boardService;
 
-    // # 게시글 전체 조회 (페이징 일단 5개로 정의)
     @ApiDocumentResponse
     @Operation(summary = "행복기록 전체 조회")
     @GetMapping("/api/boards")
     @Auth
-    public ApiResponse<GetBoardsGroupsResponse> getAllBoards(@RequestParam(required = false) Long lastBoardId,
-                                                             @Valid @MemberId Long memberId, @RequestParam(defaultValue = "newest") String orderType,
+    public ApiResponse<GetBoardsGroupsResponse> getAllBoards(@Valid @MemberId Long memberId,
+                                                             @RequestBody GetBoardsRequest request,
                                                              @PageableDefault(size = 5) Pageable pageable) {
-        Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(lastBoardId, memberId, orderType, pageable);
-        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, orderType);
+        Slice<GetBoardsResponse> getBoardsResponses = boardService.getAllBoards(memberId, request, pageable);
+        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, request.getOrderType());
 
         return ApiResponse.success(getBoardsGroupsResponse);
     }
@@ -50,22 +49,21 @@ public class BoardController {
     }
 
     // # 게시글 조회 - 해시태그
-    @ApiDocumentResponse
-    @Operation(summary = "행복기록 조회 - 해시태그")
-    @ResponseBody
-    @PostMapping ("/api/boards/tag")
-    @Auth
-    public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(
-            @RequestParam(required = false) Long lastBoardId,
-            @Valid @MemberId Long memberId,
-            @Valid @RequestBody GetBoardByTagRequest getBoardByTagRequest, @RequestParam(defaultValue = "newest") String orderType,
-            @PageableDefault(size = 5) Pageable pageable) {
-        Slice<GetBoardsResponse> getBoardsResponses =
-                boardService.getBoardsByTag(lastBoardId, memberId, getBoardByTagRequest.getTagIds(), orderType, pageable);
-        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, orderType);
-
-        return ApiResponse.success(getBoardsGroupsResponse);
-    }
+//    @ApiDocumentResponse
+//    @Operation(summary = "행복기록 조회 - 해시태그")
+//    @ResponseBody
+//    @PostMapping ("/api/boards/tag")
+//    @Auth
+//    public ApiResponse<GetBoardsGroupsResponse> getBoardsByTag(@Valid @MemberId Long memberId,
+//                                                               @RequestBody GetBoardsRequest request,
+//                                                               @RequestBody GetBoardByTagRequest tagRequest,
+//                                                               @PageableDefault(size = 5) Pageable pageable) {
+//        Slice<GetBoardsResponse> getBoardsResponses =
+//                boardService.getBoardsByTag(memberId, request, tagRequest.getTagIds(), pageable);
+//        GetBoardsGroupsResponse getBoardsGroupsResponse = boardService.getBoardsGroups(getBoardsResponses, request.getOrderType()));
+//
+//        return ApiResponse.success(getBoardsGroupsResponse);
+//    }
 
     // # 게시글 조회 - by 날짜
     @ApiDocumentResponse

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
@@ -10,6 +10,8 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardByTagRequest {
+    private GetBoardsRequest request;
+
     @NotEmpty(message = "태그 아이디를 입력해주세요.")
     private List<Long> tagIds;
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardByTagRequest.java
@@ -3,6 +3,7 @@ package com.bonheur.domain.board.model.dto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import reactor.util.annotation.Nullable;
 
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
@@ -10,7 +11,11 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetBoardByTagRequest {
-    private GetBoardsRequest request;
+    @Nullable
+    private String orderType;
+
+    @Nullable
+    private Long lastBoardId;
 
     @NotEmpty(message = "태그 아이디를 입력해주세요.")
     private List<Long> tagIds;

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsGroupsResponse.java
@@ -16,14 +16,15 @@ import java.util.stream.Collectors;
 public class GetBoardsGroupsResponse {
     private Map<String, List<GetBoardsResponse>> group;
     private String orderType; // newest : 최신, oldest : 오래된 순
+    private Boolean last; // page의 마지막 여부
 
-    public static GetBoardsGroupsResponse of(Map<String, List<GetBoardsResponse>> group, String orderType) {
+    public static GetBoardsGroupsResponse of(Map<String, List<GetBoardsResponse>> group, String orderType, Boolean last) {
         group = group.entrySet().stream().sorted(
                 orderType.equals("newest") ? Map.Entry.<String, List<GetBoardsResponse>>comparingByKey().reversed()
                         : Map.Entry.comparingByKey()).collect(Collectors.toMap(
                         Map.Entry::getKey, Map.Entry::getValue,
                         (e1, e2) -> e1,
                         LinkedHashMap::new));
-        return new GetBoardsGroupsResponse(group, orderType);
+        return new GetBoardsGroupsResponse(group, orderType, last);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsRequest.java
@@ -1,0 +1,23 @@
+package com.bonheur.domain.board.model.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import reactor.util.annotation.Nullable;
+
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetBoardsRequest {
+    @Nullable
+    private String orderType;
+
+    @Nullable
+    private Long lastBoardId;
+
+    public void update(String orderType) {
+        this.orderType = orderType;
+    }
+}

--- a/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/GetBoardsRequest.java
@@ -20,4 +20,8 @@ public class GetBoardsRequest {
     public void update(String orderType) {
         this.orderType = orderType;
     }
+
+    public static GetBoardsRequest of (String orderType, Long lastBoardId) {
+        return new GetBoardsRequest(orderType, lastBoardId);
+    }
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustom.java
@@ -14,4 +14,5 @@ public interface BoardRepositoryCustom {
     List<Integer> getCalendar(Long memberId, int year, int month, int lastDay);
     Slice<Board> findByCreatedAtWithPaging(Long lastBoardId, Long memberId, LocalDate localDate, String orderType, Pageable pageable);
     Long getNumOfBoardsByDate(Long memberId, LocalDate localDate);
+    Long getLastIdOfBoard(Long memberId, String orderType);
 }

--- a/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/board/repository/BoardRepositoryCustomImpl.java
@@ -144,6 +144,18 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom{
                 ).fetchOne();
     }
 
+    // # 작성 id 탐색 (첫, 마지막)
+    @Override
+    public Long getLastIdOfBoard(Long memberId, String orderType) {
+        return queryFactory.select(board.id).from(board)
+                .where(
+                        // memberId
+                        board.member.id.eq(memberId)
+                ).orderBy(OrderSpecifierUtil.getOrderSpecifier(orderType))
+                .limit(1)
+                .fetchOne();
+    }
+
     @Override
     public Board findBoardByIdWithMemberAndImages(Long boardId) {
         return queryFactory.select(board)

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -10,11 +10,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface BoardService {
-    Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, String orderType, Pageable pageable);
+    Slice<GetBoardsResponse> getAllBoards(Long memberId, GetBoardsRequest request, Pageable pageable);
 
     DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
 
-    Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, String orderType, Pageable pageable);
+    Slice<GetBoardsResponse> getBoardsByTag(Long memberId, GetBoardsRequest request, List<Long> tagIds, Pageable pageable);
 
     CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -14,7 +14,7 @@ public interface BoardService {
 
     DeleteBoardResponse deleteBoard(Long memberId, Long boardId);
 
-    Slice<GetBoardsResponse> getBoardsByTag(Long memberId, GetBoardsRequest request, List<Long> tagIds, Pageable pageable);
+    Slice<GetBoardsResponse> getBoardsByTag(Long memberId, GetBoardsRequest getBoardsRequest, GetBoardByTagRequest tagRequest, Pageable pageable);
 
     CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException;
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
@@ -37,11 +37,18 @@ public class BoardServiceHelper {
     }
 
     public static void isValidRequest(Long memberId, BoardRepository boardRepository, GetBoardsRequest request) {
+        if (boardRepository.getLastIdOfBoard(memberId, "oldest") == null)
+            throw new NotFoundException("작성된 게시글이 없습니다.", E404_NOT_EXISTS_WRITTEN_BOARD);
+
         if (request.getOrderType() == null) request.update("newest");
-        if (!(request.getOrderType().equals("newest") || request.getOrderType().equals("oldest"))){
+        if (!(request.getOrderType().equals("newest") || request.getOrderType().equals("oldest")))
             throw new InvalidException("게시글 정렬 순서 입력이 잘못되었습니다.", E400_INVALID_FORMAT_ORDER_TYPE);
+
+        if (request.getLastBoardId() != null) {
+            Long lastId = boardRepository.getLastIdOfBoard(memberId, "newest") + (request.getOrderType().equals("newest") ?  1 : 0);
+            Long startId = boardRepository.getLastIdOfBoard(memberId, "oldest") - (request.getOrderType().equals("oldest") ? 1 : 0);
+            if (!(startId < request.getLastBoardId() && request.getLastBoardId() < lastId))
+                throw new InvalidException("더 이상 불러올 글이 없습니다.", E400_INVALID_LAST_BOARD_ID);
         }
-        if (request.getLastBoardId()!= null && request.getLastBoardId() > boardRepository.getLastIdOfBoard(memberId))
-            throw new InvalidException("더 이상 불러올 글이 없습니다.", E400_INVALID_LAST_BOARD_ID);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
@@ -1,10 +1,11 @@
 package com.bonheur.domain.board.service;
 
 import com.bonheur.domain.board.model.Board;
+import com.bonheur.domain.board.model.dto.GetBoardsRequest;
 import com.bonheur.domain.board.repository.BoardRepository;
 import com.bonheur.domain.common.exception.ForbiddenException;
+import com.bonheur.domain.common.exception.InvalidException;
 import com.bonheur.domain.common.exception.NotFoundException;
-import com.bonheur.domain.common.exception.dto.ErrorCode;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -33,5 +34,14 @@ public class BoardServiceHelper {
             throw new ForbiddenException("해당 회원이 만든 게시글이 아닙니다.", E403_FORBIDDEN_BOARD);
         }
         return board;
+    }
+
+    public static void isValidRequest(Long memberId, BoardRepository boardRepository, GetBoardsRequest request) {
+        if (request.getOrderType() == null) request.update("newest");
+        if (!(request.getOrderType().equals("newest") || request.getOrderType().equals("oldest"))){
+            throw new InvalidException("게시글 정렬 순서 입력이 잘못되었습니다.", E400_INVALID_FORMAT_ORDER_TYPE);
+        }
+        if (request.getLastBoardId()!= null && request.getLastBoardId() > boardRepository.getLastIdOfBoard(memberId))
+            throw new InvalidException("더 이상 불러올 글이 없습니다.", E400_INVALID_LAST_BOARD_ID);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -10,6 +10,8 @@ import com.bonheur.domain.image.service.ImageServiceHelper;
 import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.repository.MemberRepository;
 import com.bonheur.domain.member.service.MemberServiceHelper;
+import com.bonheur.domain.tag.repository.TagRepository;
+import com.bonheur.domain.tag.service.TagServiceHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,6 +33,7 @@ public class BoardServiceImpl implements BoardService {
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
     private final BoardTagService boardTagService;
+    private final TagRepository tagRepository;
     private final ImageService imageService;
 
     // # 게시글 전체 조회
@@ -84,18 +87,19 @@ public class BoardServiceImpl implements BoardService {
 
     // # 게시글 조회 - by 해시태그
     // 회원 정보 인증 어노테이션 추가 필요
-//    @Override
-//    @Transactional(readOnly = true)
-//    public Slice<GetBoardsResponse> getBoardsByTag(Long memberId, List<Long> tagIds, Pageable pageable) {
-//        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
-//
-//        return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, orderType, pageable)
-//                .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
-//                        board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
-//                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
-//                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
-//                );
-//    }
+    @Override
+    @Transactional(readOnly = true)
+    public Slice<GetBoardsResponse> getBoardsByTag(Long memberId, GetBoardsRequest request, List<Long> tagIds, Pageable pageable) {
+        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
+        TagServiceHelper.isExistTag(tagRepository, memberId, tagIds);
+
+        return boardRepository.findByTagWithPaging(request.getLastBoardId(), memberId, tagIds, request.getOrderType(), pageable)
+                .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
+                        board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
+                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
+                );
+    }
 
     // # 게시글 조회 - by 날짜
     // 회원 정보 인증 어노테이션 추가 필요

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -37,8 +37,10 @@ public class BoardServiceImpl implements BoardService {
     // 회원 정보 인증 어노테이션 추가 필요
     @Override
     @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getAllBoards(Long lastBoardId, Long memberId, String orderType, Pageable pageable) {
-        return boardRepository.findAllWithPaging(lastBoardId, memberId, orderType, pageable)
+    public Slice<GetBoardsResponse> getAllBoards(Long memberId, GetBoardsRequest request, Pageable pageable) {
+        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
+
+        return boardRepository.findAllWithPaging(request.getLastBoardId(), memberId, request.getOrderType(), pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
@@ -52,7 +54,7 @@ public class BoardServiceImpl implements BoardService {
     public GetBoardsGroupsResponse getBoardsGroups(Slice<GetBoardsResponse> getBoardsResponseSlice, String orderType) {
         List<GetBoardsResponse> getBoardsResponsesOfSlice = getBoardsResponseSlice.getContent();
         return GetBoardsGroupsResponse.of(getBoardsResponsesOfSlice.stream().
-                collect(Collectors.groupingBy(GetBoardsResponse::getCreatedAtDate)), orderType);
+                collect(Collectors.groupingBy(GetBoardsResponse::getCreatedAtDate)), orderType, getBoardsResponseSlice.isLast());
     }
 
     // # Tag Name을 String List로 받아오기
@@ -82,16 +84,18 @@ public class BoardServiceImpl implements BoardService {
 
     // # 게시글 조회 - by 해시태그
     // 회원 정보 인증 어노테이션 추가 필요
-    @Override
-    @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getBoardsByTag(Long lastBoardId, Long memberId, List<Long> tagIds, String orderType, Pageable pageable) {
-        return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, orderType, pageable)
-                .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
-                        board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
-                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
-                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
-                );
-    }
+//    @Override
+//    @Transactional(readOnly = true)
+//    public Slice<GetBoardsResponse> getBoardsByTag(Long memberId, List<Long> tagIds, Pageable pageable) {
+//        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
+//
+//        return boardRepository.findByTagWithPaging(lastBoardId, memberId, tagIds, orderType, pageable)
+//                .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
+//                        board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
+//                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
+//                        board.getCreatedAt().format(DateTimeFormatter.ofPattern("a hh:mm").withLocale(Locale.forLanguageTag("en"))))
+//                );
+//    }
 
     // # 게시글 조회 - by 날짜
     // 회원 정보 인증 어노테이션 추가 필요

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -89,11 +89,11 @@ public class BoardServiceImpl implements BoardService {
     // 회원 정보 인증 어노테이션 추가 필요
     @Override
     @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getBoardsByTag(Long memberId, GetBoardsRequest request, List<Long> tagIds, Pageable pageable) {
-        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
-        TagServiceHelper.isExistTag(tagRepository, memberId, tagIds);
+    public Slice<GetBoardsResponse> getBoardsByTag(Long memberId, GetBoardsRequest getBoardsRequest, GetBoardByTagRequest tagRequest, Pageable pageable) {
+        BoardServiceHelper.isValidRequest(memberId, boardRepository, getBoardsRequest);
+        TagServiceHelper.isExistTag(tagRepository, memberId, tagRequest.getTagIds());
 
-        return boardRepository.findByTagWithPaging(request.getLastBoardId(), memberId, tagIds, request.getOrderType(), pageable)
+        return boardRepository.findByTagWithPaging(getBoardsRequest.getLastBoardId(), memberId, tagRequest.getTagIds(), getBoardsRequest.getOrderType(), pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),

--- a/src/main/java/com/bonheur/domain/common/exception/dto/ErrorCode.java
+++ b/src/main/java/com/bonheur/domain/common/exception/dto/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     E400_INVALID_UPLOAD_FILE_EXTENSION(BAD_REQUEST, false, "BR008", "잘못된 파일 확장자입니다"),
     E400_INVALID_FILE_SIZE_TOO_LARGE(BAD_REQUEST, true, "BR009", "업로드 가능한 파일 크기를 초과했습니다"),
     E400_INVALID_FILE_COUNT_TOO_MANY(BAD_REQUEST, true, "BR010", "업로드 가능한 파일 개수를 초과했습니다"),
+    E400_INVALID_FORMAT_ORDER_TYPE(BAD_REQUEST, false, "BR011", "게시글 정렬 순서 입력이 잘못되었습니다."),
+    E400_INVALID_LAST_BOARD_ID(BAD_REQUEST, true, "BR012", "더 이상 불러올 글이 없습니다."),
+
     E400_MISSING_PARAMETER(BAD_REQUEST, false, "BR100", "필수 파라미터가 입력되지 않았습니다"),
     E400_MISSING_AUTH_TOKEN_PARAMETER(BAD_REQUEST, false, "BR105", "인증 토큰을 입력해주세요"),
     E400_MISSING_FILE(BAD_REQUEST, false, "BR106", "파일을 업로드해주세요"),

--- a/src/main/java/com/bonheur/domain/common/exception/dto/ErrorCode.java
+++ b/src/main/java/com/bonheur/domain/common/exception/dto/ErrorCode.java
@@ -46,6 +46,8 @@ public enum ErrorCode {
     E404_NOT_EXISTS_BOARD(NOT_FOUND, false, "NF002", "존재하지 않는 게시글입니다"),
     E404_NOT_EXISTS_TAG(NOT_FOUND, false, "NF004", "존재하지 않는 태그입니다"),
     E404_NOT_EXISTS_FAQ(NOT_FOUND, false, "NF005", "삭제되거나 존재하지 않는 FAQ입니다"),
+    E404_NOT_EXISTS_WRITTEN_BOARD(NOT_FOUND, false, "NF006", "작성된 게시글이 없습니다."),
+
     E404_NOT_EXISTS_SIGNUP_REGISTRATION(NOT_FOUND, false, "NF010", "해당하는 가입 신청은 존재하지 않습니다"),
     E404_NOT_EXISTS_ADMIN(NOT_FOUND, false, "NF011", "해당하는 관리자는 존재하지 않습니다"),
 

--- a/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustom.java
@@ -5,4 +5,5 @@ import com.bonheur.domain.tag.model.Tag;
 public interface TagRepositoryCustom {
     Long findOwnTagByTagName(Long memberId, String tagName);
     Tag findOwnTagByTagId(Long memberId, Long tagId);
+    Long isExistTag(Long memberId, Long tagId);
 }

--- a/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
@@ -18,10 +18,8 @@ public class TagRepositoryCustomImpl implements TagRepositoryCustom {
                         // member에 해당되는 태그
                         memberTag.member.id.eq(memberId),
                         // tagName에 해당되는 태그
-                        tag.name.eq(tagName),
-                        // 매칭
-                        tag.id.eq(memberTag.tag.id)
-                ).join(memberTag).fetchOne();
+                        tag.name.eq(tagName)
+                ).join(tag.memberTags, memberTag).fetchOne();
     }
     // 생각한 쿼리 : select tag.id from tag, member_tag where tag.id=tag_id and member_tag.member_id=1 and tag.name='tag1';
 
@@ -44,9 +42,7 @@ public class TagRepositoryCustomImpl implements TagRepositoryCustom {
                         // member에 해당되는 태그
                         memberTag.member.id.eq(memberId),
                         // tagName에 해당되는 태그
-                        tag.id.eq(tagId),
-                        // 매칭
-                        tag.id.eq(memberTag.tag.id)
-                ).join(memberTag).fetchOne();
+                        tag.id.eq(tagId)
+                ).join(tag.memberTags, memberTag).fetchOne();
     }
 }

--- a/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
@@ -31,9 +31,22 @@ public class TagRepositoryCustomImpl implements TagRepositoryCustom {
                 .from(tag)
                 .join(tag.memberTags, memberTag)
                 .where(
-                        memberTag.id.eq(memberId),
+                        memberTag.member.id.eq(memberId),
                         tag.id.eq(tagId),
                         tag.id.eq(memberTag.tag.id)
                 ).fetchOne();
+    }
+
+    @Override
+    public Long isExistTag(Long memberId, Long tagId) {
+        return queryFactory.select(tag.count()).from(tag, memberTag)
+                .where(
+                        // member에 해당되는 태그
+                        memberTag.member.id.eq(memberId),
+                        // tagName에 해당되는 태그
+                        tag.id.eq(tagId),
+                        // 매칭
+                        tag.id.eq(memberTag.tag.id)
+                ).join(memberTag).fetchOne();
     }
 }

--- a/src/main/java/com/bonheur/domain/tag/service/TagServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/tag/service/TagServiceHelper.java
@@ -6,6 +6,8 @@ import com.bonheur.domain.tag.repository.TagRepository;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 import static com.bonheur.domain.common.exception.dto.ErrorCode.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,5 +19,12 @@ public class TagServiceHelper {
             throw new NotFoundException("존재하지 않는 태그입니다", E404_NOT_EXISTS_TAG);
         }
         return tag;
+    }
+
+    public static void isExistTag(TagRepository tagRepository, Long memberId, List<Long> tagIds) {
+        for (Long id : tagIds) {
+            if (tagRepository.isExistTag(memberId, id) == 0)
+                throw new NotFoundException("존재하지 않는 태그입니다.", E404_NOT_EXISTS_TAG);
+        }
     }
 }


### PR DESCRIPTION
## 개요
#160 

## 생각했던 발생 가능한 오류
[🔥발생 가능한 오류 _ 재재 정리 노션](https://www.notion.so/part-3695421dce5e4d168222614d534e9d6f?pvs=4)
#### 요약
| API | 오류 |
|:---:|:---:|
|게시글 전체 조회 | 게시글없음, lastBoardId 범위, 정렬순서 |
|게시글 태그별 조회 | 게시글없음, lastBoardId 범위, 정렬순서, 태그없음, 필수필드|

## 작업사항
- 더 많은 parameter 생성으로 복잡해질 것 같아서 ``GetBoardsRequest`` DTO 생성
- ``GetBoardsByTag`` DTO에 ``GetBoardsRequest`` 넣어서 받음
- 예외 처리

[💡변경된 내용 _ 재재 정리 노션](https://www.notion.so/07329767438d4f35bfd47e76303c640a?pvs=4)
=> 프론트 보여주려구 작성한 건데 이해에 도움될 것 같아서 넣습니다 :)