### PR TITLE
[hotfix] findOwnTagByTagId 함수 수정

### DIFF
--- a/src/main/java/com/bonheur/domain/board/model/dto/CreateBoardRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/CreateBoardRequest.java
@@ -5,6 +5,7 @@ import com.bonheur.domain.member.model.Member;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter
@@ -12,6 +13,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateBoardRequest {
     @NotBlank
+    @Size(max = 3000)
     private String contents;
 
     private List<Long> tagIds;

--- a/src/main/java/com/bonheur/domain/board/model/dto/CreateBoardRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/CreateBoardRequest.java
@@ -13,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateBoardRequest {
     @NotBlank
-    @Size(max = 3000)
+    @Size(max = 3000, message="3000글자를 초과했습니다.")
     private String contents;
 
     private List<Long> tagIds;

--- a/src/main/java/com/bonheur/domain/board/model/dto/CreateBoardResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/CreateBoardResponse.java
@@ -2,15 +2,13 @@ package com.bonheur.domain.board.model.dto;
 
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateBoardResponse {
     private Long boardId;
 
-    public static CreateBoardResponse of(@NotNull Long boardId){
+    public static CreateBoardResponse of(Long boardId){
         return new CreateBoardResponse(boardId);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/model/dto/UpdateBoardRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/UpdateBoardRequest.java
@@ -3,6 +3,7 @@ package com.bonheur.domain.board.model.dto;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter
@@ -11,6 +12,7 @@ import java.util.List;
 public class UpdateBoardRequest {
 
     @NotBlank
+    @Size(max = 3000)
     private String contents;
 
     private List<Long> tagIds;

--- a/src/main/java/com/bonheur/domain/board/model/dto/UpdateBoardRequest.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/UpdateBoardRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class UpdateBoardRequest {
 
     @NotBlank
-    @Size(max = 3000)
+    @Size(max = 3000, message="3000글자를 초과했습니다.")
     private String contents;
 
     private List<Long> tagIds;

--- a/src/main/java/com/bonheur/domain/board/model/dto/UpdateBoardResponse.java
+++ b/src/main/java/com/bonheur/domain/board/model/dto/UpdateBoardResponse.java
@@ -2,15 +2,13 @@ package com.bonheur.domain.board.model.dto;
 
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateBoardResponse {
     private Long boardId;
 
-    public static UpdateBoardResponse of(@NotNull Long boardId){
+    public static UpdateBoardResponse of(Long boardId){
         return new UpdateBoardResponse(boardId);
     }
 }

--- a/src/main/java/com/bonheur/domain/member/model/dto/UpdateMemberProfileResponse.java
+++ b/src/main/java/com/bonheur/domain/member/model/dto/UpdateMemberProfileResponse.java
@@ -2,15 +2,13 @@ package com.bonheur.domain.member.model.dto;
 
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateMemberProfileResponse {
     private Long memberId;
 
-    public static UpdateMemberProfileResponse of(@NotNull Long memberId){
+    public static UpdateMemberProfileResponse of(Long memberId){
         return new UpdateMemberProfileResponse(memberId);
     }
 }

--- a/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
@@ -31,9 +31,8 @@ public class TagRepositoryCustomImpl implements TagRepositoryCustom {
                 .from(tag)
                 .join(tag.memberTags, memberTag)
                 .where(
-                        memberTag.id.eq(memberId),
-                        tag.id.eq(tagId),
-                        tag.id.eq(memberTag.tag.id)
+                        memberTag.member.id.eq(memberId),
+                        tag.id.eq(tagId)
                 ).fetchOne();
     }
 }


### PR DESCRIPTION
## 개요
`hotfix/findOwnTagByTagId-#189`에 해당 (#189) 

## 작업사항
- [x] memberTag.member.id.eq(memberId)에서 member가 빠져서 수정
<img width="355" alt="스크린샷 2023-02-11 오전 1 24 57" src="https://user-images.githubusercontent.com/75533232/218151528-fd4497a2-88e5-4306-af97-bb42af7563e4.png">
