### PR TITLE
[Fix] 프로필 기본 이미지 조회 로직 및 RequestPart 어노테이션 수정

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -11,13 +11,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -71,14 +69,13 @@ public class BoardController {
     @GetMapping("/api/boards/date")
     @Auth
     public ApiResponse<GetBoardsByDateResponse> getBoardsByDate(@Valid @MemberId Long memberId,
-                                                                @RequestParam(required = false) Long lastBoardId,
-                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate,
-                                                                @RequestParam(defaultValue = "newest") String orderType,
-                                                                Pageable pageable) {
-        Slice<GetBoardsResponse> getBoardsResponses = boardService.getBoardsByDate(memberId, lastBoardId,localDate, orderType, pageable);
-        Long count = boardService.getNumOfBoardsByDate(memberId, localDate);
+                                                                @RequestBody GetBoardsRequest request,
+                                                                @RequestParam String localDate,
+                                                                @PageableDefault(size = 5) Pageable pageable) {
+        Slice<GetBoardsResponse> getBoardsResponses = boardService.getBoardsByDate(memberId, request, localDate, pageable);
+        Long numOfBoardsByDate = boardService.getNumOfBoardsByDate(memberId, localDate);
 
-        GetBoardsByDateResponse getBoardsByDateResponse = GetBoardsByDateResponse.of(count, getBoardsResponses);
+        GetBoardsByDateResponse getBoardsByDateResponse = GetBoardsByDateResponse.of(numOfBoardsByDate, getBoardsResponses);
         return ApiResponse.success(getBoardsByDateResponse);
     }
 

--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -98,7 +98,7 @@ public class BoardController {
     @Auth
     public ApiResponse<CreateBoardResponse> createBoard(
             @Valid @MemberId Long memberId,
-            @RequestPart(value = "images") List<MultipartFile> images,
+            @RequestPart(required = false, value = "images") List<MultipartFile> images,
             @RequestPart @Valid CreateBoardRequest createBoardRequest) throws IOException {
 
         return ApiResponse.success(boardService.createBoard(memberId, createBoardRequest, images));
@@ -111,7 +111,7 @@ public class BoardController {
     public ApiResponse<UpdateBoardResponse> updateBoard(
             @Valid @MemberId Long memberId,
             @PathVariable("boardId") Long boardId,
-            @RequestPart(value = "images") List<MultipartFile> images,
+            @RequestPart(required = false, value = "images") List<MultipartFile> images,
             @RequestPart @Valid UpdateBoardRequest updateBoardRequest) throws IOException {
 
         return ApiResponse.success(boardService.updateBoard(memberId, boardId, updateBoardRequest, images));

--- a/src/main/java/com/bonheur/domain/board/service/BoardService.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardService.java
@@ -26,7 +26,7 @@ public interface BoardService {
 
     List<GetCalendarResponse> getCalendar(Long memberId, int year, int month);
 
-    Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, String orderType, Pageable pageable);
+    Slice<GetBoardsResponse> getBoardsByDate(Long memberId, GetBoardsRequest request, String localDate, Pageable pageable);
 
-    Long getNumOfBoardsByDate(Long memberId, LocalDate localDate);
+    Long getNumOfBoardsByDate(Long memberId, String localDate);
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
@@ -9,9 +9,6 @@ import com.bonheur.domain.common.exception.NotFoundException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.util.Calendar;
-
 import static com.bonheur.domain.common.exception.dto.ErrorCode.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -39,7 +36,7 @@ public class BoardServiceHelper {
         return board;
     }
 
-    public static void isValidRequest(Long memberId, BoardRepository boardRepository, GetBoardsRequest request) {
+    public static void isValidBoardRequest(Long memberId, BoardRepository boardRepository, GetBoardsRequest request) {
         if (boardRepository.getLastIdOfBoard(memberId, "oldest") == null)
             throw new NotFoundException("작성된 게시글이 없습니다.", E404_NOT_EXISTS_WRITTEN_BOARD);
 
@@ -53,43 +50,5 @@ public class BoardServiceHelper {
             if (!(startId < request.getLastBoardId() && request.getLastBoardId() < lastId))
                 throw new InvalidException("더 이상 불러올 글이 없습니다.", E400_INVALID_LAST_BOARD_ID);
         }
-    }
-
-    public static LocalDate isValidDateFormat(String localDate) { // 가능한 포맷 : yyyy-MM-dd
-        // 1. - 체크(포맷)
-        if (localDate.charAt(4) != '-' || localDate.charAt(7) != '-' || localDate.length() != 10)
-            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
-        int idx = 0;
-        while (idx < 10) {
-            if (idx == 4 || idx == 7) {
-                idx++; continue;
-            }
-            if (localDate.charAt(idx) < '0' || localDate.charAt(idx) > '9') throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
-            System.out.println("idx : "+idx+"\n");
-            idx++;
-        }
-
-        // 2. 날짜 범위 체크
-        int year = Integer.parseInt(localDate.substring(0, 4));
-        int month = Integer.parseInt(localDate.substring(5, 7));
-        int day = Integer.parseInt(localDate.substring(8, 10));
-
-        int monthLastDay = getLastDay(year, month);
-        if (day < 1 || day > monthLastDay)
-            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
-
-        // 3. 반환
-        return LocalDate.of(year, month, day);
-    }
-
-    public static int getLastDay(int year, int month) {
-        Calendar cal = Calendar.getInstance();
-        cal.set(year, month-1, 1);
-        int lastDay = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
-
-        if (year < 2022 || year > 2100 || month < 1 || month > 12)
-            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
-
-        return lastDay;
     }
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
@@ -9,6 +9,9 @@ import com.bonheur.domain.common.exception.NotFoundException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+import java.util.Calendar;
+
 import static com.bonheur.domain.common.exception.dto.ErrorCode.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -50,5 +53,34 @@ public class BoardServiceHelper {
             if (!(startId < request.getLastBoardId() && request.getLastBoardId() < lastId))
                 throw new InvalidException("더 이상 불러올 글이 없습니다.", E400_INVALID_LAST_BOARD_ID);
         }
+    }
+
+    public static LocalDate isValidDateFormat(String localDate) { // 가능한 포맷 : yyyy-MM-dd
+        // 1. - 체크(포맷)
+        if (localDate.charAt(4) != '-' || localDate.charAt(7) != '-' || localDate.length() != 10)
+            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+        int idx = 0;
+        while (idx < 10) {
+            if (idx == 4 || idx == 7) {
+                idx++; continue;
+            }
+            if (localDate.charAt(idx) < '0' || localDate.charAt(idx) > '9') throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+            System.out.println("idx : "+idx+"\n");
+            idx++;
+        }
+
+        // 2. 날짜 범위 체크
+        int year = Integer.parseInt(localDate.substring(0, 4));
+        int month = Integer.parseInt(localDate.substring(5, 7));
+        int day = Integer.parseInt(localDate.substring(8, 10));
+
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month-1, 1);
+        int monthLastDay = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
+        if (year < 2022 || month < 1 || month > 12 || day < 1 || day > monthLastDay)
+            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+
+        // 3. 반환
+        return LocalDate.of(year, month, day);
     }
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceHelper.java
@@ -74,13 +74,22 @@ public class BoardServiceHelper {
         int month = Integer.parseInt(localDate.substring(5, 7));
         int day = Integer.parseInt(localDate.substring(8, 10));
 
-        Calendar cal = Calendar.getInstance();
-        cal.set(year, month-1, 1);
-        int monthLastDay = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
-        if (year < 2022 || month < 1 || month > 12 || day < 1 || day > monthLastDay)
+        int monthLastDay = getLastDay(year, month);
+        if (day < 1 || day > monthLastDay)
             throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
 
         // 3. 반환
         return LocalDate.of(year, month, day);
+    }
+
+    public static int getLastDay(int year, int month) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month-1, 1);
+        int lastDay = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
+
+        if (year < 2022 || year > 2100 || month < 1 || month > 12)
+            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+
+        return lastDay;
     }
 }

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -13,6 +13,7 @@ import com.bonheur.domain.member.repository.MemberRepository;
 import com.bonheur.domain.member.service.MemberServiceHelper;
 import com.bonheur.domain.tag.repository.TagRepository;
 import com.bonheur.domain.tag.service.TagServiceHelper;
+import com.bonheur.util.DateUtilHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -44,7 +45,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional(readOnly = true)
     public Slice<GetBoardsResponse> getAllBoards(Long memberId, GetBoardsRequest request, Pageable pageable) {
-        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
+        BoardServiceHelper.isValidBoardRequest(memberId, boardRepository, request);
 
         return boardRepository.findAllWithPaging(request.getLastBoardId(), memberId, request.getOrderType(), pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
@@ -93,7 +94,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional(readOnly = true)
     public Slice<GetBoardsResponse> getBoardsByTag(Long memberId, GetBoardsRequest getBoardsRequest, GetBoardByTagRequest tagRequest, Pageable pageable) {
-        BoardServiceHelper.isValidRequest(memberId, boardRepository, getBoardsRequest);
+        BoardServiceHelper.isValidBoardRequest(memberId, boardRepository, getBoardsRequest);
         TagServiceHelper.isExistTag(tagRepository, memberId, tagRequest.getTagIds());
 
         return boardRepository.findByTagWithPaging(getBoardsRequest.getLastBoardId(), memberId, tagRequest.getTagIds(), getBoardsRequest.getOrderType(), pageable)
@@ -109,8 +110,8 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional(readOnly = true)
     public Slice<GetBoardsResponse> getBoardsByDate(Long memberId, GetBoardsRequest request, String localDate, Pageable pageable) {
-        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
-        LocalDate date = BoardServiceHelper.isValidDateFormat(localDate);
+        BoardServiceHelper.isValidBoardRequest(memberId, boardRepository, request);
+        LocalDate date = DateUtilHelper.isValidDateFormat(localDate);
 
         return boardRepository.findByCreatedAtWithPaging(request.getLastBoardId(), memberId, date, request.getOrderType(), pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
@@ -124,7 +125,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional(readOnly = true)
     public Long getNumOfBoardsByDate(Long memberId, String localDate) {
-        LocalDate date = BoardServiceHelper.isValidDateFormat(localDate);
+        LocalDate date = DateUtilHelper.isValidDateFormat(localDate);
         Long numOfBoardsByDate = boardRepository.getNumOfBoardsByDate(memberId, date);
         if (numOfBoardsByDate == 0)
             throw new NotFoundException("작성된 게시글이 없습니다.", E404_NOT_EXISTS_WRITTEN_BOARD);
@@ -138,7 +139,7 @@ public class BoardServiceImpl implements BoardService {
     public List<GetCalendarResponse> getCalendar(Long memberId, int year, int month) {
 
         // 해당 달의 마지막 날 계산
-        int lastDay = BoardServiceHelper.getLastDay(year, month);
+        int lastDay = DateUtilHelper.getLastDay(year, month);
 
         List<GetCalendarResponse> getCalendarList = new ArrayList<>();
         int idx = 0;

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -151,13 +151,15 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException {
         Member member = MemberServiceHelper.getExistMember(memberRepository, memberId);
-        ImageServiceHelper.validateImageCount(images, 5L);
         Board board = boardRepository.save(request.toEntity(member));
 
         if (!request.getTagIds().isEmpty()) {
             boardTagService.createBoardTags(memberId, board, request.getTagIds());   //게시글과 해시태그 연결
         }
-        imageService.uploadImages(board, images);
+        if(images != null)  {
+            ImageServiceHelper.validateImageCount(images, 5L);
+            imageService.uploadImages(board, images);
+        }
         return CreateBoardResponse.of(board.getId());
     }
 
@@ -165,12 +167,16 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public UpdateBoardResponse updateBoard(Long memberId, Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException{
         MemberServiceHelper.validateMemberExists(memberRepository, memberId);
-        ImageServiceHelper.validateImageCount(images, 5L);
 
         Board board = BoardServiceHelper.getBoardByMemberId(memberId, boardRepository, boardId);
         board.update(request.getContents());    //게시글 수정
         boardTagService.updateBoardTags(memberId, board, request.getTagIds()); //게시글 태그 수정
+
+        if(images != null)  {
+            ImageServiceHelper.validateImageCount(images, 5L);
+        }
         imageService.updateImages(board, images); //이미지 수정
+
         return UpdateBoardResponse.of(boardId);
     }
 

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -4,6 +4,7 @@ import com.bonheur.domain.board.model.Board;
 import com.bonheur.domain.board.model.dto.*;
 import com.bonheur.domain.board.repository.BoardRepository;
 import com.bonheur.domain.boardtag.service.BoardTagService;
+import com.bonheur.domain.common.exception.NotFoundException;
 import com.bonheur.domain.image.model.Image;
 import com.bonheur.domain.image.service.ImageService;
 import com.bonheur.domain.image.service.ImageServiceHelper;
@@ -26,6 +27,8 @@ import org.springframework.data.domain.Slice;
 
 import java.time.format.DateTimeFormatter;
 import java.util.stream.Collectors;
+
+import static com.bonheur.domain.common.exception.dto.ErrorCode.E404_NOT_EXISTS_WRITTEN_BOARD;
 
 @Service
 @RequiredArgsConstructor
@@ -105,8 +108,11 @@ public class BoardServiceImpl implements BoardService {
     // 회원 정보 인증 어노테이션 추가 필요
     @Override
     @Transactional(readOnly = true)
-    public Slice<GetBoardsResponse> getBoardsByDate(Long memberId, Long lastBoardId, LocalDate localDate, String orderType, Pageable pageable) {
-        return boardRepository.findByCreatedAtWithPaging(lastBoardId, memberId, localDate, orderType, pageable)
+    public Slice<GetBoardsResponse> getBoardsByDate(Long memberId, GetBoardsRequest request, String localDate, Pageable pageable) {
+        BoardServiceHelper.isValidRequest(memberId, boardRepository, request);
+        LocalDate date = BoardServiceHelper.isValidDateFormat(localDate);
+
+        return boardRepository.findByCreatedAtWithPaging(request.getLastBoardId(), memberId, date, request.getOrderType(), pageable)
                 .map(board -> GetBoardsResponse.of(board.getId(), board.getContents(), getBoardTagsName(board.getBoardTags()),
                         board.getImages().isEmpty() ? null : board.getImages().get(0).getUrl(),
                         board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일")),
@@ -117,8 +123,12 @@ public class BoardServiceImpl implements BoardService {
     // # 게시글 조회 - by 날짜 count
     @Override
     @Transactional(readOnly = true)
-    public Long getNumOfBoardsByDate(Long memberId, LocalDate localDate) {
-        return boardRepository.getNumOfBoardsByDate(memberId, localDate);
+    public Long getNumOfBoardsByDate(Long memberId, String localDate) {
+        LocalDate date = BoardServiceHelper.isValidDateFormat(localDate);
+        Long numOfBoardsByDate = boardRepository.getNumOfBoardsByDate(memberId, date);
+        if (numOfBoardsByDate == 0)
+            throw new NotFoundException("작성된 게시글이 없습니다.", E404_NOT_EXISTS_WRITTEN_BOARD);
+        return numOfBoardsByDate;
     }
 
     // # 캘린더 조회

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -138,9 +138,7 @@ public class BoardServiceImpl implements BoardService {
     public List<GetCalendarResponse> getCalendar(Long memberId, int year, int month) {
 
         // 해당 달의 마지막 날 계산
-        Calendar cal = Calendar.getInstance();
-        cal.set(year, month-1, 1);
-        int lastDay = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
+        int lastDay = BoardServiceHelper.getLastDay(year, month);
 
         List<GetCalendarResponse> getCalendarList = new ArrayList<>();
         int idx = 0;

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -76,7 +76,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     public DeleteBoardResponse deleteBoard(Long memberId, Long boardId) {
-        Board board = boardRepository.findById(boardId).orElseThrow(()-> new IllegalArgumentException("존재하지 않는 글입니다."));
+        Board board = BoardServiceHelper.getExistBoard(boardRepository, boardId);
         Long writer = board.getMember().getId();
         if (writer.equals(memberId)) {
             imageService.deleteImagesIns3(board); // s3, 테이블에서 이미지 삭제

--- a/src/main/java/com/bonheur/domain/common/exception/dto/ErrorCode.java
+++ b/src/main/java/com/bonheur/domain/common/exception/dto/ErrorCode.java
@@ -16,8 +16,9 @@ public enum ErrorCode {
     E400_INVALID_UPLOAD_FILE_EXTENSION(BAD_REQUEST, false, "BR008", "잘못된 파일 확장자입니다"),
     E400_INVALID_FILE_SIZE_TOO_LARGE(BAD_REQUEST, true, "BR009", "업로드 가능한 파일 크기를 초과했습니다"),
     E400_INVALID_FILE_COUNT_TOO_MANY(BAD_REQUEST, true, "BR010", "업로드 가능한 파일 개수를 초과했습니다"),
-    E400_INVALID_FORMAT_ORDER_TYPE(BAD_REQUEST, false, "BR011", "게시글 정렬 순서 입력이 잘못되었습니다."),
-    E400_INVALID_LAST_BOARD_ID(BAD_REQUEST, true, "BR012", "더 이상 불러올 글이 없습니다."),
+    E400_INVALID_FORMAT_ORDER_TYPE(BAD_REQUEST, false, "BR011", "게시글 정렬 순서 입력이 잘못되었습니다"),
+    E400_INVALID_LAST_BOARD_ID(BAD_REQUEST, true, "BR012", "더 이상 불러올 글이 없습니다"),
+    E400_INVALID_FORMAT_DATE(BAD_REQUEST, false, "BR013", "잘못된 날짜 형식이 입력되었습니다"),
 
     E400_MISSING_PARAMETER(BAD_REQUEST, false, "BR100", "필수 파라미터가 입력되지 않았습니다"),
     E400_MISSING_AUTH_TOKEN_PARAMETER(BAD_REQUEST, false, "BR105", "인증 토큰을 입력해주세요"),

--- a/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
@@ -40,7 +40,9 @@ public class ImageServiceImpl implements ImageService{
         if(!oldImages.isEmpty()) {
             imageRepository.deleteAllInBatch(oldImages);          //기존의 이미지 삭제
         }
-        uploadImages(board, images);            //새로운 이미지 업로드
+        if(images != null){
+            uploadImages(board, images);            //새로운 이미지 업로드
+        }
     }
 
     // # image s3, 테이블에서 삭제

--- a/src/main/java/com/bonheur/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bonheur/domain/member/controller/MemberController.java
@@ -31,7 +31,7 @@ public class MemberController {
     @PatchMapping("/api/member/profiles")
     @Auth
     public ApiResponse<UpdateMemberProfileResponse> updateProfile(
-            @RequestPart MultipartFile image,
+            @RequestPart(required = false) MultipartFile image,
             @RequestPart @Valid UpdateMemberProfileRequest updateMemberProfileRequest,
             @Valid @MemberId Long memberId) throws IOException {
         return ApiResponse.success(memberService.updateMemberProfile(memberId, updateMemberProfileRequest, image));

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import com.bonheur.domain.member.model.dto.*;
 import com.bonheur.domain.member.repository.MemberRepository;
 import com.bonheur.util.FileUploadUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,6 +27,9 @@ public class MemberServiceImpl implements MemberService{
     private final MemberRepository memberRepository;
     private final BoardRepository boardRepository;
     private final FileUploadUtil fileUploadUtil;
+
+    @Value("${member.default-profile}")
+    private String defaultProfileURL;
 
     @Override
     @Transactional
@@ -59,7 +63,7 @@ public class MemberServiceImpl implements MemberService{
     public GetMemberProfileResponse getMemberProfile(Long memberId){
         Member member = MemberServiceHelper.getExistMember(memberRepository, memberId);
         return GetMemberProfileResponse.of(member.getNickname(),
-                (member.getProfile() == null) ? null : member.getProfile().getUrl());
+                (member.getProfile() == null) ? defaultProfileURL : member.getProfile().getUrl());
     }
 
     @Override

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -46,14 +46,12 @@ public class MemberServiceImpl implements MemberService{
         Member member = MemberServiceHelper.getExistMember(memberRepository, memberId);
         member.updateNickname(request.getNickname());
 
-        if(member.getProfile() != null){    //기존의 프로필 이미지가 있는 경우
-            fileUploadUtil.deleteFile(member.getProfile().getPath());   //프로필 이미지 s3에서 삭제
-            member.updateProfile(null, null); //member 테이블에서 이미지 삭제
+        if(member.getProfile() != null){
+            fileUploadUtil.deleteFile(member.getProfile().getPath());
+            member.updateProfile(null, null);
         }
-        if(!image.isEmpty()){   //기존의 프로필 이미지를 새로운 이미지로 변경하는 경우
-            FileUploadResponse fileUploadResponse = fileUploadUtil.uploadFile("image", image);  //프로필 이미지 s3에 업로드
-            member.updateProfile(fileUploadResponse.getFileUrl(), fileUploadResponse.getFilePath());  //프로필 이미지 변경
-        }
+        FileUploadResponse fileUploadResponse = uploadProfileImage(image);
+        member.updateProfile(fileUploadResponse.getFileUrl(), fileUploadResponse.getFilePath());
 
         return UpdateMemberProfileResponse.of(memberId);
     }

--- a/src/main/java/com/bonheur/domain/tag/service/TagServiceHelper.java
+++ b/src/main/java/com/bonheur/domain/tag/service/TagServiceHelper.java
@@ -27,4 +27,11 @@ public class TagServiceHelper {
                 throw new NotFoundException("존재하지 않는 태그입니다.", E404_NOT_EXISTS_TAG);
         }
     }
+
+    public static Long getTagIdByTagName(TagRepository tagRepository, Long memberId, String tagName) {
+        Long tagId = tagRepository.findOwnTagByTagName(memberId, tagName);
+        if (tagId == null)
+            throw new NotFoundException("존재하지 않는 태그입니다.", E404_NOT_EXISTS_TAG);
+        return tagId;
+    }
 }

--- a/src/main/java/com/bonheur/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/tag/service/TagServiceImpl.java
@@ -41,6 +41,6 @@ public class TagServiceImpl implements TagService{
     @Override
     @Transactional
     public GetTagIdResponse getTagIdByTagName(Long memberId, String tagName) {
-        return GetTagIdResponse.of(tagRepository.findOwnTagByTagName(memberId, tagName));
+        return GetTagIdResponse.of(TagServiceHelper.getTagIdByTagName(tagRepository, memberId, tagName));
     }
 }

--- a/src/main/java/com/bonheur/util/DateUtilHelper.java
+++ b/src/main/java/com/bonheur/util/DateUtilHelper.java
@@ -1,0 +1,51 @@
+package com.bonheur.util;
+
+import com.bonheur.domain.common.exception.InvalidException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.Calendar;
+
+import static com.bonheur.domain.common.exception.dto.ErrorCode.E400_INVALID_FORMAT_DATE;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DateUtilHelper {
+    public static LocalDate isValidDateFormat(String localDate) { // 가능한 포맷 : yyyy-MM-dd
+        // 1. - 체크(포맷)
+        if (localDate.charAt(4) != '-' || localDate.charAt(7) != '-' || localDate.length() != 10)
+            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+        int idx = 0;
+        while (idx < 10) {
+            if (idx == 4 || idx == 7) {
+                idx++; continue;
+            }
+            if (localDate.charAt(idx) < '0' || localDate.charAt(idx) > '9') throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+            System.out.println("idx : "+idx+"\n");
+            idx++;
+        }
+
+        // 2. 날짜 범위 체크
+        int year = Integer.parseInt(localDate.substring(0, 4));
+        int month = Integer.parseInt(localDate.substring(5, 7));
+        int day = Integer.parseInt(localDate.substring(8, 10));
+
+        int monthLastDay = getLastDay(year, month);
+        if (day < 1 || day > monthLastDay)
+            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+
+        // 3. 반환
+        return LocalDate.of(year, month, day);
+    }
+
+    public static int getLastDay(int year, int month) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month-1, 1);
+        int lastDay = cal.getActualMaximum(Calendar.DAY_OF_MONTH);
+
+        if (year < 2022 || year > 2100 || month < 1 || month > 12)
+            throw new InvalidException("잘못된 날짜 형식이 입력되었습니다", E400_INVALID_FORMAT_DATE);
+
+        return lastDay;
+    }
+}


### PR DESCRIPTION
## 개요
`fix/getProfileImage-#200`에 해당 (#200) 

## 작업사항_프로필 기본 이미지 조회 로직 수정
- [x] 프로필 조회시, 이미지의 url이 null인 경우 기본 프로필 이미지 url을 반환

## 작업사항_RequestPart 어노테이션 수정
- [x] 게시글 작성 및 수정, 프로필 수정 관련 RequestPart 어노테이션의 required = false로 설정
- 이미지를 업로드하지 않는 경우 request Body에 입력하지 않아도 되도록 변경
- 기존의 회원가입시 프로필 이미지 업로드 관련 RequestPart 어노테이션의 required = false이므로 이미지 업로드 관련 어노테이션 사용을 통일시키기 위해서 변경함.

## 내용
### 프로필 조회(기본 이미지)하는 경우
![image](https://user-images.githubusercontent.com/75533232/218496808-bda8773c-cfed-4671-b4e6-cbbe70e3e74e.png)

### 프로필 조회(회원이 업로드한 이미지)하는 경우
![image](https://user-images.githubusercontent.com/75533232/218496871-89c7d2c2-b533-46f7-b668-ce10183221b3.png)

### 이미지 업로드하지 않고, 게시글 작성하는 경우
![image](https://user-images.githubusercontent.com/75533232/218497508-a66b713e-22b6-4bfa-bb1d-a18e5d88a939.png)

### 이미지 업로드하지 않고, 게시글 수정하는 경우
![image](https://user-images.githubusercontent.com/75533232/218497548-a5a225fb-d0ac-4c62-bcd6-c0fcf64d547d.png)

### 이미지 업로드하지 않고, 프로필 수정하는 경우
![image](https://user-images.githubusercontent.com/75533232/218497370-52abe60d-0040-4396-899b-41090ad83b08.png)
