### PR TITLE
[Fix] 프로필 기본 이미지 조회 로직 및 RequestPart 어노테이션 수정

### DIFF
--- a/src/main/java/com/bonheur/domain/board/controller/BoardController.java
+++ b/src/main/java/com/bonheur/domain/board/controller/BoardController.java
@@ -98,7 +98,7 @@ public class BoardController {
     @Auth
     public ApiResponse<CreateBoardResponse> createBoard(
             @Valid @MemberId Long memberId,
-            @RequestPart(value = "images") List<MultipartFile> images,
+            @RequestPart(required = false, value = "images") List<MultipartFile> images,
             @RequestPart @Valid CreateBoardRequest createBoardRequest) throws IOException {
 
         return ApiResponse.success(boardService.createBoard(memberId, createBoardRequest, images));
@@ -111,7 +111,7 @@ public class BoardController {
     public ApiResponse<UpdateBoardResponse> updateBoard(
             @Valid @MemberId Long memberId,
             @PathVariable("boardId") Long boardId,
-            @RequestPart(value = "images") List<MultipartFile> images,
+            @RequestPart(required = false, value = "images") List<MultipartFile> images,
             @RequestPart @Valid UpdateBoardRequest updateBoardRequest) throws IOException {
 
         return ApiResponse.success(boardService.updateBoard(memberId, boardId, updateBoardRequest, images));

--- a/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/board/service/BoardServiceImpl.java
@@ -151,13 +151,15 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public CreateBoardResponse createBoard(Long memberId, CreateBoardRequest request, List<MultipartFile> images) throws IOException {
         Member member = MemberServiceHelper.getExistMember(memberRepository, memberId);
-        ImageServiceHelper.validateImageCount(images, 5L);
         Board board = boardRepository.save(request.toEntity(member));
 
         if (!request.getTagIds().isEmpty()) {
             boardTagService.createBoardTags(memberId, board, request.getTagIds());   //게시글과 해시태그 연결
         }
-        imageService.uploadImages(board, images);
+        if(images != null)  {
+            ImageServiceHelper.validateImageCount(images, 5L);
+            imageService.uploadImages(board, images);
+        }
         return CreateBoardResponse.of(board.getId());
     }
 
@@ -165,12 +167,16 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public UpdateBoardResponse updateBoard(Long memberId, Long boardId, UpdateBoardRequest request, List<MultipartFile> images) throws IOException{
         MemberServiceHelper.validateMemberExists(memberRepository, memberId);
-        ImageServiceHelper.validateImageCount(images, 5L);
 
         Board board = BoardServiceHelper.getBoardByMemberId(memberId, boardRepository, boardId);
         board.update(request.getContents());    //게시글 수정
         boardTagService.updateBoardTags(memberId, board, request.getTagIds()); //게시글 태그 수정
+
+        if(images != null)  {
+            ImageServiceHelper.validateImageCount(images, 5L);
+        }
         imageService.updateImages(board, images); //이미지 수정
+
         return UpdateBoardResponse.of(boardId);
     }
 

--- a/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/image/service/ImageServiceImpl.java
@@ -40,7 +40,9 @@ public class ImageServiceImpl implements ImageService{
         if(!oldImages.isEmpty()) {
             imageRepository.deleteAllInBatch(oldImages);          //기존의 이미지 삭제
         }
-        uploadImages(board, images);            //새로운 이미지 업로드
+        if(images != null){
+            uploadImages(board, images);            //새로운 이미지 업로드
+        }
     }
 
     // # image s3, 테이블에서 삭제

--- a/src/main/java/com/bonheur/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bonheur/domain/member/controller/MemberController.java
@@ -31,7 +31,7 @@ public class MemberController {
     @PatchMapping("/api/member/profiles")
     @Auth
     public ApiResponse<UpdateMemberProfileResponse> updateProfile(
-            @RequestPart MultipartFile image,
+            @RequestPart(required = false) MultipartFile image,
             @RequestPart @Valid UpdateMemberProfileRequest updateMemberProfileRequest,
             @Valid @MemberId Long memberId) throws IOException {
         return ApiResponse.success(memberService.updateMemberProfile(memberId, updateMemberProfileRequest, image));

--- a/src/main/java/com/bonheur/domain/member/model/property/MemberProperties.java
+++ b/src/main/java/com/bonheur/domain/member/model/property/MemberProperties.java
@@ -1,0 +1,12 @@
+package com.bonheur.domain.member.model.property;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class MemberProperties {
+    @Value("${member.default-profile}")
+    private String defaultProfileURL;
+}

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import com.bonheur.domain.member.model.dto.*;
 import com.bonheur.domain.member.repository.MemberRepository;
 import com.bonheur.util.FileUploadUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,6 +27,9 @@ public class MemberServiceImpl implements MemberService{
     private final MemberRepository memberRepository;
     private final BoardRepository boardRepository;
     private final FileUploadUtil fileUploadUtil;
+
+    @Value("${member.default-profile}")
+    private String defaultProfileURL;
 
     @Override
     @Transactional
@@ -59,7 +63,7 @@ public class MemberServiceImpl implements MemberService{
     public GetMemberProfileResponse getMemberProfile(Long memberId){
         Member member = MemberServiceHelper.getExistMember(memberRepository, memberId);
         return GetMemberProfileResponse.of(member.getNickname(),
-                (member.getProfile() == null) ? null : member.getProfile().getUrl());
+                (member.getProfile() == null) ? defaultProfileURL : member.getProfile().getUrl());
     }
 
     @Override

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -4,10 +4,10 @@ import com.bonheur.domain.board.repository.BoardRepository;
 import com.bonheur.domain.file.dto.FileUploadResponse;
 import com.bonheur.domain.member.model.Member;
 import com.bonheur.domain.member.model.dto.*;
+import com.bonheur.domain.member.model.property.MemberProperties;
 import com.bonheur.domain.member.repository.MemberRepository;
 import com.bonheur.util.FileUploadUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,9 +27,7 @@ public class MemberServiceImpl implements MemberService{
     private final MemberRepository memberRepository;
     private final BoardRepository boardRepository;
     private final FileUploadUtil fileUploadUtil;
-
-    @Value("${member.default-profile}")
-    private String defaultProfileURL;
+    private final MemberProperties memberProperties;
 
     @Override
     @Transactional
@@ -61,7 +59,7 @@ public class MemberServiceImpl implements MemberService{
     public GetMemberProfileResponse getMemberProfile(Long memberId){
         Member member = MemberServiceHelper.getExistMember(memberRepository, memberId);
         return GetMemberProfileResponse.of(member.getNickname(),
-                (member.getProfile() == null) ? defaultProfileURL : member.getProfile().getUrl());
+                (member.getProfile() == null) ? memberProperties.getDefaultProfileURL() : member.getProfile().getUrl());
     }
 
     @Override

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -46,14 +46,12 @@ public class MemberServiceImpl implements MemberService{
         Member member = MemberServiceHelper.getExistMember(memberRepository, memberId);
         member.updateNickname(request.getNickname());
 
-        if(member.getProfile() != null){    //기존의 프로필 이미지가 있는 경우
-            fileUploadUtil.deleteFile(member.getProfile().getPath());   //프로필 이미지 s3에서 삭제
-            member.updateProfile(null, null); //member 테이블에서 이미지 삭제
+        if(member.getProfile() != null){
+            fileUploadUtil.deleteFile(member.getProfile().getPath());
+            member.updateProfile(null, null);
         }
-        if(!image.isEmpty()){   //기존의 프로필 이미지를 새로운 이미지로 변경하는 경우
-            FileUploadResponse fileUploadResponse = fileUploadUtil.uploadFile("image", image);  //프로필 이미지 s3에 업로드
-            member.updateProfile(fileUploadResponse.getFileUrl(), fileUploadResponse.getFilePath());  //프로필 이미지 변경
-        }
+        FileUploadResponse fileUploadResponse = uploadProfileImage(image);
+        member.updateProfile(fileUploadResponse.getFileUrl(), fileUploadResponse.getFilePath());
 
         return UpdateMemberProfileResponse.of(memberId);
     }


### PR DESCRIPTION
## 개요
`fix/getProfileImage-#200`에 해당 (#200) 

## 작업사항_프로필 기본 이미지 조회 로직 수정
- [x] 프로필 조회시, 이미지의 url이 null인 경우 기본 프로필 이미지 url을 반환

## 작업사항_RequestPart 어노테이션 수정
- [x] 게시글 작성 및 수정, 프로필 수정 관련 RequestPart 어노테이션의 required = false로 설정
- 이미지를 업로드하지 않는 경우 request Body에 입력하지 않아도 되도록 변경
- 기존의 회원가입시 프로필 이미지 업로드 관련 RequestPart 어노테이션의 required = false이므로 이미지 업로드 관련 어노테이션 사용을 통일시키기 위해서 변경함.

## 내용
### 프로필 조회(기본 이미지)하는 경우
![image](https://user-images.githubusercontent.com/75533232/218496808-bda8773c-cfed-4671-b4e6-cbbe70e3e74e.png)

### 프로필 조회(회원이 업로드한 이미지)하는 경우
![image](https://user-images.githubusercontent.com/75533232/218496871-89c7d2c2-b533-46f7-b668-ce10183221b3.png)

### 이미지 업로드하지 않고, 게시글 작성하는 경우
![image](https://user-images.githubusercontent.com/75533232/218497508-a66b713e-22b6-4bfa-bb1d-a18e5d88a939.png)

### 이미지 업로드하지 않고, 게시글 수정하는 경우
![image](https://user-images.githubusercontent.com/75533232/218497548-a5a225fb-d0ac-4c62-bcd6-c0fcf64d547d.png)

### 이미지 업로드하지 않고, 프로필 수정하는 경우
![image](https://user-images.githubusercontent.com/75533232/218497370-52abe60d-0040-4396-899b-41090ad83b08.png)
