### PR TITLE
Fix : 최근 tag 조회 도메인 변경(member -> tag)

### DIFF
--- a/src/main/java/com/bonheur/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bonheur/domain/member/controller/MemberController.java
@@ -84,12 +84,4 @@ public class MemberController {
     public ApiResponse<List<FindMonthRecordResponse>> findMyMonthRecord(@Valid @MemberId Long memberId) {
         return ApiResponse.success(memberService.findMyMonthRecord(memberId));
     }
-
-    @ApiDocumentResponse
-    @Operation(summary = "회원 최근 사용 태그 조회")
-    @GetMapping("/api/member/tags")
-    @Auth
-    public ApiResponse<List<GetTagUsedByMemberResponse>> getTagUsedByMember(@Valid @MemberId Long memberId) {
-        return ApiResponse.success(memberService.getTagUsedByMember(memberId));
-    }
 }

--- a/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustom.java
@@ -18,7 +18,4 @@ public interface MemberRepositoryCustom {
     Long findNightTimeRecordByMemberId(Long memberId);
     List<FindDayRecordResponse> findDayRecordByMemberId(Long memberId);
     List<FindMonthRecordResponse> findMonthRecordByMemberId(Long memberId);
-
-
-    List<Tag> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -159,21 +159,5 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .distinct()
                 .fetch();
     }
-
-    @Override
-    public List<Tag> getTagUsedByMember(Long memberId) {
-        return queryFactory.select(tag)
-                .from(tag)
-                .leftJoin(tag.memberTags,memberTag).fetchJoin()
-                .leftJoin(memberTag.member).fetchJoin()
-                .where(
-                        memberTag.member.id.eq(memberId)
-                )
-                .distinct()
-                .orderBy(memberTag.updatedAt.desc())
-                .offset(0)
-                .limit(5)
-                .fetch();
-    }
 }
 

--- a/src/main/java/com/bonheur/domain/member/service/MemberService.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberService.java
@@ -24,6 +24,4 @@ public interface MemberService {
 
     List<FindDayRecordResponse> findMyDayRecord(Long memberId);
     List<FindMonthRecordResponse> findMyMonthRecord(Long memberId);
-
-    List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/member/service/MemberServiceImpl.java
@@ -165,12 +165,6 @@ public class MemberServiceImpl implements MemberService{
     }
 
     @Override
-    @Transactional
-    public List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId) {
-        return memberRepository.getTagUsedByMember(memberId).stream().map(tag -> GetTagUsedByMemberResponse.of(tag.getId(),tag.getName())).collect(Collectors.toList());
-    }
-
-    @Override
     public FileUploadResponse uploadProfileImage(MultipartFile profileImage) throws IOException {
         if(profileImage != null)
             return fileUploadUtil.uploadFile("image", profileImage);

--- a/src/main/java/com/bonheur/domain/tag/controller/TagController.java
+++ b/src/main/java/com/bonheur/domain/tag/controller/TagController.java
@@ -4,6 +4,7 @@ import com.bonheur.config.interceptor.Auth;
 import com.bonheur.config.resolver.MemberId;
 import com.bonheur.config.swagger.dto.ApiDocumentResponse;
 import com.bonheur.domain.common.dto.ApiResponse;
+import com.bonheur.domain.tag.model.dto.GetTagUsedByMemberResponse;
 import com.bonheur.domain.tag.model.dto.CreateTagRequest;
 import com.bonheur.domain.tag.model.dto.CreateTagResponse;
 import com.bonheur.domain.tag.model.dto.GetTagIdResponse;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -38,5 +40,13 @@ public class TagController {
                                                            @Valid @MemberId Long memberId) {
         GetTagIdResponse getTagIdResponse = tagService.getTagIdByTagName(memberId, tagName);
         return ApiResponse.success(getTagIdResponse);
+    }
+
+    @ApiDocumentResponse
+    @Operation(summary = "회원 최근 사용 태그 조회")
+    @GetMapping("/api/tags")
+    @Auth
+    public ApiResponse<List<GetTagUsedByMemberResponse>> getTagUsedByMember(@Valid @MemberId Long memberId) {
+        return ApiResponse.success(tagService.getTagUsedByMember(memberId));
     }
 }

--- a/src/main/java/com/bonheur/domain/tag/model/dto/GetTagUsedByMemberResponse.java
+++ b/src/main/java/com/bonheur/domain/tag/model/dto/GetTagUsedByMemberResponse.java
@@ -1,4 +1,4 @@
-package com.bonheur.domain.member.model.dto;
+package com.bonheur.domain.tag.model.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustom.java
+++ b/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustom.java
@@ -2,8 +2,11 @@ package com.bonheur.domain.tag.repository;
 
 import com.bonheur.domain.tag.model.Tag;
 
+import java.util.List;
+
 public interface TagRepositoryCustom {
     Long findOwnTagByTagName(Long memberId, String tagName);
     Tag findOwnTagByTagId(Long memberId, Long tagId);
     Long isExistTag(Long memberId, Long tagId);
+    List<Tag> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
+++ b/src/main/java/com/bonheur/domain/tag/repository/TagRepositoryCustomImpl.java
@@ -4,6 +4,8 @@ import com.bonheur.domain.tag.model.Tag;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 import static com.bonheur.domain.tag.model.QTag.tag;
 import static com.bonheur.domain.membertag.model.QMemberTag.memberTag;
 
@@ -43,5 +45,21 @@ public class TagRepositoryCustomImpl implements TagRepositoryCustom {
                         // tagName에 해당되는 태그
                         tag.id.eq(tagId)
                 ).join(tag.memberTags, memberTag).fetchOne();
+    }
+
+    @Override
+    public List<Tag> getTagUsedByMember(Long memberId) {
+        return queryFactory.select(tag)
+                .from(tag)
+                .leftJoin(tag.memberTags,memberTag).fetchJoin()
+                .leftJoin(memberTag.member).fetchJoin()
+                .where(
+                        memberTag.member.id.eq(memberId)
+                )
+                .distinct()
+                .orderBy(memberTag.updatedAt.desc())
+                .offset(0)
+                .limit(5)
+                .fetch();
     }
 }

--- a/src/main/java/com/bonheur/domain/tag/service/TagService.java
+++ b/src/main/java/com/bonheur/domain/tag/service/TagService.java
@@ -1,5 +1,6 @@
 package com.bonheur.domain.tag.service;
 
+import com.bonheur.domain.tag.model.dto.GetTagUsedByMemberResponse;
 import com.bonheur.domain.tag.model.dto.CreateTagResponse;
 import com.bonheur.domain.tag.model.dto.GetTagIdResponse;
 
@@ -10,4 +11,5 @@ TagService {
     CreateTagResponse createTags(Long memberId, List<String> tags);
 
     GetTagIdResponse getTagIdByTagName(Long memberId, String tagName);
+    List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId);
 }

--- a/src/main/java/com/bonheur/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/bonheur/domain/tag/service/TagServiceImpl.java
@@ -1,6 +1,7 @@
 package com.bonheur.domain.tag.service;
 
 import com.bonheur.domain.common.BaseEntity;
+import com.bonheur.domain.tag.model.dto.GetTagUsedByMemberResponse;
 import com.bonheur.domain.member.repository.MemberRepository;
 import com.bonheur.domain.member.service.MemberServiceHelper;
 import com.bonheur.domain.membertag.service.MemberTagService;
@@ -42,5 +43,11 @@ public class TagServiceImpl implements TagService{
     @Transactional
     public GetTagIdResponse getTagIdByTagName(Long memberId, String tagName) {
         return GetTagIdResponse.of(TagServiceHelper.getTagIdByTagName(tagRepository, memberId, tagName));
+    }
+
+    @Override
+    @Transactional
+    public List<GetTagUsedByMemberResponse> getTagUsedByMember(Long memberId) {
+        return tagRepository.getTagUsedByMember(memberId).stream().map(tag -> GetTagUsedByMemberResponse.of(tag.getId(),tag.getName())).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 개요
#220 

## 작업사항
- ``member dto``에 있던 GetTagUsedByMemberResponse ``tag dto``로 이동
- ``member controller`` 내용 ``/api/tags``로 ``tag controller``로 이동
- ``member service`` 의 getTagUsedByMember ``tag service``로 이동
- repo 메서드 이동
![image](https://user-images.githubusercontent.com/80443295/218953809-b99ce0e2-8242-4499-8776-2e2f85a17fa9.png)
